### PR TITLE
IOS-XR interface model

### DIFF
--- a/models/iosxr/interfaces/deleted_example_01.txt
+++ b/models/iosxr/interfaces/deleted_example_01.txt
@@ -1,0 +1,11 @@
+# Using deleted
+
+- name: Delete IOS interfaces as in given arguments
+  iosxr_interfaces:
+    config:
+      - name: GigabitEthernet0/0/0/2
+        description: 'Configured by Ansible'
+      - name: GigabitEthernet0/0/0/3
+        description: 'Configured by Ansible Network'
+        mtu: 2000
+    operation: deleted

--- a/models/iosxr/interfaces/deleted_example_01.txt
+++ b/models/iosxr/interfaces/deleted_example_01.txt
@@ -24,7 +24,7 @@
 #  dot1q native vlan 1021
 # !
 
-- name: Delete IOS interfaces as in given arguments
+- name: Delete attributes of given interfaces (Note: This won't delete the interface itself)
   iosxr_interfaces:
     config:
       - name: GigabitEthernet0/0/0/2

--- a/models/iosxr/interfaces/deleted_example_01.txt
+++ b/models/iosxr/interfaces/deleted_example_01.txt
@@ -1,11 +1,50 @@
 # Using deleted
 
+# Before state:
+# -------------
+#
+# viosxr#show running-config interface
+# interface GigabitEthernet0/0/0/1
+#  shutdown
+# !
+# interface GigabitEthernet0/0/0/2
+#  description Configured and Overridden by Ansible Network
+#  vrf custB
+#  ipv4 address 178.18.169.23 255.255.255.0
+#  speed 1000
+#  dot1q native vlan 30
+# !
+# interface GigabitEthernet0/0/0/3
+#  description Configured and Overridden by Ansible Network
+#  mtu 2000
+#  vrf custB
+#  ipv4 address 10.10.0.2 255.255.255.0
+#  duplex full
+#  shutdown
+#  dot1q native vlan 1021
+# !
+
 - name: Delete IOS interfaces as in given arguments
   iosxr_interfaces:
     config:
       - name: GigabitEthernet0/0/0/2
-        description: 'Configured by Ansible'
       - name: GigabitEthernet0/0/0/3
-        description: 'Configured by Ansible Network'
-        mtu: 2000
     operation: deleted
+
+# After state:
+# -------------
+#
+# viosxr#show running-config interface
+# interface GigabitEthernet0/0/0/1
+#  shutdown
+# !
+# interface GigabitEthernet0/0/0/2
+#  vrf custB
+#  ipv4 address 178.18.169.23 255.255.255.0
+#  dot1q native vlan 30
+# !
+# interface GigabitEthernet0/0/0/3
+#  vrf custB
+#  ipv4 address 10.10.0.2 255.255.255.0
+#  dot1q native vlan 1021
+# !

--- a/models/iosxr/interfaces/iosxr_interface.yaml
+++ b/models/iosxr/interfaces/iosxr_interface.yaml
@@ -11,9 +11,9 @@ info:
   network_os: iosxr
   resource: interfaces
   version_added: 2.9
-  short_description: 'Manage Interface on Cisco IOS network devices.'
+  short_description: 'Manage interface attributes on Cisco IOSXR network devices'
   description:
-  - Manage Interface on Cisco IOS-XR network devices.
+  - This module manages the interface attributes on Cisco IOS-XR network devices.
   authors:
   - Sumit Jaiswal (@justjais)
   extends_documentation_fragment: iosxr
@@ -34,22 +34,22 @@ schema:
 definitions:
   config_dict:
     description:
-    - The some_dict.
+    - A dictionary of interface options
     type: object
     properties:
       name:
         description:
-        - Name of the interface to configure in C(type + path) format. e.g. C(GigabitEthernet0/0/0/0)
+        - Full name of the interface to configure in C(type + path) format. e.g. C(GigabitEthernet0/0/0/0)
         type: str
         required: true
       description:
         description:
-        - Description of Interface being configured.
+        - Interface description.
         type: str
       enabled:
         description:
-        - Removes the shutdown configuration, which removes the forced administrative down on the interface,
-          enabling it to move to an up or down state.
+        - Administrative state of the interface.
+        - Set the value to C(true) to administratively enable the interface or C(false) to disable it.
         type: bool
         default: true
       active:
@@ -67,7 +67,7 @@ definitions:
         choices: ['10', '100', '1000']
       mtu:
         description:
-        - Sets the MTU value for the interface. Range is between 64 and 65535. Applicable for Ethernet interface only.
+        - Sets the MTU value for the interface. Range is between 64 and 65535. Applicable for Ethernet interfaces only.
         type: str
       duplex:
         description:

--- a/models/iosxr/interfaces/iosxr_interface.yaml
+++ b/models/iosxr/interfaces/iosxr_interface.yaml
@@ -33,10 +33,10 @@ DOCUMENTATION: |
           - Interface description.
           type: str
         enable:
-          default: true
+          default: True
           description:
           - Administrative state of the interface.
-          - Set the value to C(true) to administratively enable the interface or C(false) to disable it.
+          - Set the value to C(True) to administratively enable the interface or C(False) to disable it.
           type: bool
         active:
           default: active

--- a/models/iosxr/interfaces/iosxr_interface.yaml
+++ b/models/iosxr/interfaces/iosxr_interface.yaml
@@ -1,0 +1,93 @@
+Igenerator_version: 1.0
+metadata:
+  version: 1.1
+  status:
+  - preview
+  supported_by:
+  - 'Ansible Network'
+  copyright_str: Copyright 2019 Red Hat
+  license: gpl-3.0.txt
+info:
+  network_os: iosxr
+  resource: interfaces
+  version_added: 2.9
+  short_description: 'Manage Interface on Cisco IOS network devices.'
+  description:
+  - Manage Interface on Cisco IOS-XR network devices.
+  authors:
+  - Sumit Jaiswal (@justjais)
+  extends_documentation_fragment: iosxr
+  notes:
+    - Tested against IOS-XR Version 6.1.3 on VIRL
+schema:
+  type: object
+  description: The schema used for the argspec and docstring
+  properties:
+    config:
+      type: array
+      description: The provided configuration
+      items:
+        $ref: '#/definitions/config_dict'
+    state:
+      $ref: '#/definitions/state'
+
+definitions:
+  config_dict:
+    description:
+    - The some_dict.
+    type: object
+    properties:
+      name:
+        description:
+        - Name of the interface to configure in C(type + path) format. e.g. C(GigabitEthernet0/0/0/0)
+        type: str
+        required: true
+      description:
+        description:
+        - Description of Interface being configured.
+        type: str
+      enabled:
+        description:
+        - Removes the shutdown configuration, which removes the forced administrative down on the interface,
+          enabling it to move to an up or down state.
+        type: bool
+        default: true
+      active:
+        description:
+        - Whether the interface is C(active) or C(preconfigured). Preconfiguration allows you to configure modular
+          services cards before they are inserted into the router. When the cards are inserted, they are instantly
+          configured. Active cards are the ones already inserted.
+        type: str
+        choices: ['active', 'preconfigure']
+        default: active
+      speed:
+        description:
+        - Configure the speed for an interface. Default is auto-negotiation when not configured.
+        type: str
+        choices: ['10', '100', '1000']
+      mtu:
+        description:
+        - Sets the MTU value for the interface. Range is between 64 and 65535. Applicable for Ethernet interface only.
+        type: str
+      duplex:
+        description:
+        - Configures the interface duplex mode. Default is auto-negotiation when not configured.
+        type: str
+        default: auto
+        choices: ['full', 'half']
+
+  state:
+    description:
+    - The state the configuration should be left in
+    type: str
+    enum:
+    - merged
+    - replaced
+    - overridden
+    - deleted
+    default: merged
+examples:
+- merged_example_01.txt
+- replaced_example_01.txt
+- overridden_example_01.txt
+- deleted_example_01.txt

--- a/models/iosxr/interfaces/iosxr_interface.yaml
+++ b/models/iosxr/interfaces/iosxr_interface.yaml
@@ -1,93 +1,78 @@
-Igenerator_version: 1.0
-metadata:
-  version: 1.1
-  status:
-  - preview
-  supported_by:
-  - 'Ansible Network'
-  copyright_str: Copyright 2019 Red Hat
-  license: gpl-3.0.txt
-info:
-  network_os: iosxr
-  resource: interfaces
+---
+GENERATOR_VERSION: '1.0'
+
+ANSIBLE_METADATA: |
+    {
+      'metadata_version': '1.1',
+      'status': ['preview'],
+      'supported_by': 'network'
+    }
+NETWORK_OS: iosxr
+RESOURCE: interfaces
+COPYRIGHT: Copyright 2019 Red Hat
+
+DOCUMENTATION: |
+  module: iosxr_interfaces
   version_added: 2.9
-  short_description: 'Manage interface attributes on Cisco IOSXR network devices'
-  description:
-  - This module manages the interface attributes on Cisco IOS-XR network devices.
-  authors:
-  - Sumit Jaiswal (@justjais)
-  extends_documentation_fragment: iosxr
-  notes:
-    - Tested against IOS-XR Version 6.1.3 on VIRL
-schema:
-  type: object
-  description: The schema used for the argspec and docstring
-  properties:
+  short_description: Manage interface attributes on Cisco IOS-XR network devices
+  description: This module manages the interface attributes on Cisco IOS-XR network devices.
+  author: Sumit Jaiswal (@justjais)
+  options:
     config:
-      type: array
-      description: The provided configuration
-      items:
-        $ref: '#/definitions/config_dict'
+      description: A dictionary of interface options
+      type: list
+      elements: dict
+      suboptions:
+        name:
+          description:
+          - Full name of the interface to configure in C(type + path) format. e.g. C(GigabitEthernet0/0/0/0)
+          type: str
+          required: True
+        description:
+          description:
+          - Interface description.
+          type: str
+        enable:
+          default: true
+          description:
+          - Administrative state of the interface.
+          - Set the value to C(true) to administratively enable the interface or C(false) to disable it.
+          type: bool
+        active:
+          default: active
+          description:
+          - Whether the interface is C(active) or C(preconfigured). Preconfiguration allows you to configure modular
+            services cards before they are inserted into the router. When the cards are inserted, they are instantly
+            configured. Active cards are the ones already inserted.
+          type: str
+          choices: ['active', 'preconfigure']
+        speed:
+          description:
+          - Configure the speed for an interface. Default is auto-negotiation when not configured.
+          type: str
+          choices: ['10', '100', '1000']
+        mtu:
+          description:
+          - Sets the MTU value for the interface. Range is between 64 and 65535. Applicable for Ethernet interfaces only.
+          type: str
+        duplex:
+          default: auto
+          description:
+          - Configures the interface duplex mode. Default is auto-negotiation when not configured.
+          type: str
+          choices: ['full', 'half']
     state:
-      $ref: '#/definitions/state'
-
-definitions:
-  config_dict:
-    description:
-    - A dictionary of interface options
-    type: object
-    properties:
-      name:
-        description:
-        - Full name of the interface to configure in C(type + path) format. e.g. C(GigabitEthernet0/0/0/0)
-        type: str
-        required: true
+      choices:
+      - merged
+      - replaced
+      - overridden
+      - deleted
+      default: merged
       description:
-        description:
-        - Interface description.
-        type: str
-      enabled:
-        description:
-        - Administrative state of the interface.
-        - Set the value to C(true) to administratively enable the interface or C(false) to disable it.
-        type: bool
-        default: true
-      active:
-        description:
-        - Whether the interface is C(active) or C(preconfigured). Preconfiguration allows you to configure modular
-          services cards before they are inserted into the router. When the cards are inserted, they are instantly
-          configured. Active cards are the ones already inserted.
-        type: str
-        choices: ['active', 'preconfigure']
-        default: active
-      speed:
-        description:
-        - Configure the speed for an interface. Default is auto-negotiation when not configured.
-        type: str
-        choices: ['10', '100', '1000']
-      mtu:
-        description:
-        - Sets the MTU value for the interface. Range is between 64 and 65535. Applicable for Ethernet interfaces only.
-        type: str
-      duplex:
-        description:
-        - Configures the interface duplex mode. Default is auto-negotiation when not configured.
-        type: str
-        default: auto
-        choices: ['full', 'half']
-
-  state:
-    description:
-    - The state the configuration should be left in
-    type: str
-    enum:
-    - merged
-    - replaced
-    - overridden
-    - deleted
-    default: merged
-examples:
-- merged_example_01.txt
-- replaced_example_01.txt
-- overridden_example_01.txt
-- deleted_example_01.txt
+      - The state the configuration should be left in
+      type: str
+EXAMPLES:
+  - deleted_example_01.txt
+  - merged_example_01.txt
+  - overridden_example_01.txt
+  - replaced_example_01.txt

--- a/models/iosxr/interfaces/merged_example_01.txt
+++ b/models/iosxr/interfaces/merged_example_01.txt
@@ -1,13 +1,57 @@
 # Using merged
 
-- name: Configure Ethernet interfaces
+# Before state:
+# -------------
+#
+# viosxr#show running-config interface
+# interface GigabitEthernet0/0/0/1
+#  shutdown
+# !
+# interface GigabitEthernet0/0/0/2
+#  vrf custB
+#  ipv4 address 178.18.169.23 255.255.255.0
+#  dot1q native vlan 30
+# !
+# interface GigabitEthernet0/0/0/3
+#  description Replaced by Ansible Team
+#  mtu 2000
+#  vrf custB
+#  ipv4 address 10.10.0.2 255.255.255.0
+#  dot1q native vlan 1021
+# !
+
+- name: Merge provided configuration with device configuration
   iosxr_interfaces:
     config:
       - name: GigabitEthernet0/0/0/2
-        description: 'Configured by Ansible'
+        description: 'Configured and Merged by Ansible Network'
         enabled: True
       - name: GigabitEthernet0/0/0/3
-        description: 'Configured by Ansible Network'
+        description: 'Configured and Merged by Ansible Network'
         enabled: False
         duplex: full
+        mtu: 2600
     operation: merged
+
+# After state:
+# ------------
+#
+# viosxr#show running-config interface
+# interface GigabitEthernet0/0/0/1
+#  shutdown
+# !
+# interface GigabitEthernet0/0/0/2
+#  description Configured and Merged by Ansible Network
+#  vrf custB
+#  ipv4 address 178.18.169.23 255.255.255.0
+#  dot1q native vlan 30
+# !
+# interface GigabitEthernet0/0/0/3
+#  description Configured and Merged by Ansible Network
+#  mtu 2600
+#  vrf custB
+#  ipv4 address 10.10.0.2 255.255.255.0
+#  duplex full
+#  shutdown
+#  dot1q native vlan 1021
+# !

--- a/models/iosxr/interfaces/merged_example_01.txt
+++ b/models/iosxr/interfaces/merged_example_01.txt
@@ -1,0 +1,13 @@
+# Using merged
+
+- name: Configure Ethernet interfaces
+  iosxr_interfaces:
+    config:
+      - name: GigabitEthernet0/0/0/2
+        description: 'Configured by Ansible'
+        enabled: True
+      - name: GigabitEthernet0/0/0/3
+        description: 'Configured by Ansible Network'
+        enabled: False
+        duplex: full
+    operation: merged

--- a/models/iosxr/interfaces/overridden_example_01.txt
+++ b/models/iosxr/interfaces/overridden_example_01.txt
@@ -1,14 +1,61 @@
 # Using overridden
 
-- name: Override interfaces
+# Before state:
+# -------------
+#
+# viosxr#show running-config interface
+# interface GigabitEthernet0/0/0/1
+#  shutdown
+# !
+# interface GigabitEthernet0/0/0/2
+#  description Configured by Ansible
+#  vrf custB
+#  ipv4 address 178.18.169.23 255.255.255.0
+#  dot1q native vlan 30
+# !
+# interface GigabitEthernet0/0/0/3
+#  description Configured by Ansible
+#  mtu 2600
+#  vrf custB
+#  ipv4 address 10.10.0.2 255.255.255.0
+#  duplex full
+#  shutdown
+#  dot1q native vlan 1021
+# !
+
+- name: Override device configuration of all interfaces with provided configuration
   iosxr_interfaces:
     config:
       - name: GigabitEthernet0/0/0/2
-        description: 'Configured by Ansible'
-        enabled: True
-        duplex: half
-      - name: GigabitEthernet0/0/0/3
-        description: 'Configured by Ansible Network'
-        enabled: False
+        description: 'Configured and Overridden by Ansible Network'
         speed: 1000
+      - name: GigabitEthernet0/0/0/3
+        description: 'Configured and Overridden by Ansible Network'
+        enabled: False
+        duplex: full
+        mtu: 2000
     operation: overridden
+
+# After state:
+# -------------
+#
+# viosxr#show running-config interface
+# interface GigabitEthernet0/0/0/1
+#  shutdown
+# !
+# interface GigabitEthernet0/0/0/2
+#  description Configured and Overridden by Ansible Network
+#  vrf custB
+#  ipv4 address 178.18.169.23 255.255.255.0
+#  speed 1000
+#  dot1q native vlan 30
+# !
+# interface GigabitEthernet0/0/0/3
+#  description Configured and Overridden by Ansible Network
+#  mtu 2000
+#  vrf custB
+#  ipv4 address 10.10.0.2 255.255.255.0
+#  duplex full
+#  shutdown
+#  dot1q native vlan 1021
+# !

--- a/models/iosxr/interfaces/overridden_example_01.txt
+++ b/models/iosxr/interfaces/overridden_example_01.txt
@@ -1,0 +1,14 @@
+# Using overridden
+
+- name: Override interfaces
+  iosxr_interfaces:
+    config:
+      - name: GigabitEthernet0/0/0/2
+        description: 'Configured by Ansible'
+        enabled: True
+        duplex: half
+      - name: GigabitEthernet0/0/0/3
+        description: 'Configured by Ansible Network'
+        enabled: False
+        speed: 1000
+    operation: overridden

--- a/models/iosxr/interfaces/replaced_example_01.txt
+++ b/models/iosxr/interfaces/replaced_example_01.txt
@@ -1,0 +1,14 @@
+# Using replaced
+
+- name: Configure following interfaces and replace their existing config
+  iosxr_interfaces:
+    config:
+      - name: GigabitEthernet0/0/0/2
+        description: Configured by Ansible
+        enabled: True
+        mtu: 2000
+      - name: GigabitEthernet0/0/0/3
+        description: 'Configured by Ansible Network'
+        enabled: False
+        duplex: half
+    operation: replaced

--- a/models/iosxr/interfaces/replaced_example_01.txt
+++ b/models/iosxr/interfaces/replaced_example_01.txt
@@ -24,11 +24,11 @@
   iosxr_interfaces:
     config:
       - name: GigabitEthernet0/0/0/2
-        description: Configured by Ansible
+        description: Configured and Replaced by Ansible
         enabled: True
         mtu: 2000
       - name: GigabitEthernet0/0/0/3
-        description: 'Configured by Ansible Network'
+        description: Configured and Replaced by Ansible
         enabled: False
         duplex: half
     operation: replaced

--- a/models/iosxr/interfaces/replaced_example_01.txt
+++ b/models/iosxr/interfaces/replaced_example_01.txt
@@ -1,6 +1,26 @@
 # Using replaced
 
-- name: Configure following interfaces and replace their existing config
+# Before state:
+# -------------
+#
+# viosxr#show running-config interface
+# interface GigabitEthernet0/0/0/1
+#  description Configured by Ansible
+#  shutdown
+# !
+# interface GigabitEthernet0/0/0/2
+#  description Test
+#  vrf custB
+#  ipv4 address 178.18.169.23 255.255.255.0
+#  dot1q native vlan 30
+# !
+# interface GigabitEthernet0/0/0/3
+#  vrf custB
+#  ipv4 address 10.10.0.2 255.255.255.0
+#  dot1q native vlan 1021
+# !
+
+- name: Replaces device configuration of listed interfaces with provided configuration
   iosxr_interfaces:
     config:
       - name: GigabitEthernet0/0/0/2
@@ -12,3 +32,27 @@
         enabled: False
         duplex: half
     operation: replaced
+
+# After state:
+# -------------
+#
+# viosxr#show running-config interface
+# interface GigabitEthernet0/0/0/1
+#  description Configured by Ansible
+#  shutdown
+# !
+# interface GigabitEthernet0/0/0/2
+#  description Configured and Replaced by Ansible
+#  mtu 2000
+#  vrf custB
+#  ipv4 address 178.18.169.23 255.255.255.0
+#  dot1q native vlan 30
+# !
+# interface GigabitEthernet0/0/0/3
+#  description Configured and Replaced by Ansible Network
+#  vrf custB
+#  ipv4 address 10.10.0.2 255.255.255.0
+#  duplex half
+#  shutdown
+#  dot1q native vlan 1021
+# !


### PR DESCRIPTION
**Docstring**
```
#!/usr/bin/python
# -*- coding: utf-8 -*-
# Copyright 2019 Red Hat Inc.
# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

##############################################
################# WARNING ####################
##############################################
###
### This file is auto generated by the resource
###   module builder playbook.
###
### Do not edit this file manually.
###
### Changes to this file will be over written
###   by the resource module builder.
###
### Changes should be made in the model used to
###   generate this file or in the resource module
###   builder template.
###
##############################################
##############################################
##############################################

"""
The module file for ios_interfaces
"""

from __future__ import absolute_import, division, print_function
from ansible.module_utils.basic import AnsibleModule
from ansible_collections.ansible_network.network.plugins.module_utils. \
     iosxr.config.interfaces.interfaces import Interfaces

ANSIBLE_METADATA = {'metadata_version': '1.1',
                    'status': [u'preview'],
                    'supported_by': [u'Ansible Network']}


DOCUMENTATION = """
---
module: iosxr_interfaces
version_added: 2.9
short_description: Manage Interface on Cisco IOS-XR network devices.
description: Manage Interface on Cisco IOS-XR network devices.
author: [u'Sumit Jaiswal (@justjais)']
options:
  config:
    description: The provided configuration
    suboptions:
      name:
        description:
        - Name of the interface to configure in C(type + path) format. e.g. C(GigabitEthernet0/0/0/0).
        type: str
        required: true
      description:
        description:
        - Description of Interface being configured.
        type: str
      enabled:
        description:
        - Removes the shutdown configuration, which removes the forced administrative down on the interface,
          enabling it to move to an up or down state.
        type: bool
        default: true
      active:
        description:
        - Whether the interface is C(active) or C(preconfigured). Preconfiguration allows you to configure modular
          services cards before they are inserted into the router. When the cards are inserted, they are instantly
          configured. Active cards are the ones already inserted.
        choices: ['active', 'preconfigure']
        default: active
      speed:
        description:
        - Configure the speed for an interface. Default is auto-negotiation when not configured.
        type: str
        choices: ['10', '100', '1000']
      mtu:
        description:
        - Sets the MTU value for the interface. Range is between 64 and 65535. Applicable for Ethernet interface only.
        type: str
      duplex:
        description:
        - Configures the interface duplex mode. Default is auto-negotiation when not configured.
          Applicable for ethernet interface only.
        type: str
        default: auto
        choices: ['full', 'half']
  state:
    choices:
    - merged
    - replaced
    - overridden
    - deleted
    default: merged
    description:
    - The state the configuration should be left in
    type: str
"""

EXAMPLES = """
---

# Using merged

- name: Configure Ethernet interfaces
  iosxr_interfaces:
    config:
      - name: GigabitEthernet0/0/0/2
        description: 'Configured by Ansible'
        enabled: True
      - name: GigabitEthernet0/0/0/3
        description: 'Configured by Ansible Network'
        enabled: False
        duplex: full
    operation: merged

# Using replaced

- name: Configure following interfaces and replace their existing config
  iosxr_interfaces:
    config:
      - name: GigabitEthernet0/0/0/2
        description: Configured by Ansible
        enabled: True
        mtu: 2000
      - name: GigabitEthernet0/0/0/3
        description: 'Configured by Ansible Network'
        enabled: False
        duplex: half
    operation: replaced

# Using overridden

- name: Override interfaces
  iosxr_interfaces:
    config:
      - name: GigabitEthernet0/0/0/2
        description: 'Configured by Ansible'
        enabled: True
        duplex: half
      - name: GigabitEthernet0/0/0/3
        description: 'Configured by Ansible Network'
        enabled: False
        speed: 1000
    operation: overridden

# Using deleted

- name: Delete IOS interfaces as in given arguments
  iosxr_interfaces:
    config:
      - name: GigabitEthernet0/0/0/2
        description: 'Configured by Ansible'
      - name: GigabitEthernet0/0/0/3
        description: 'Configured by Ansible Network'
        mtu: 2000
    operation: deleted

"""
```

**Layout**

```
plugins
   ├── action
   ├── filter
   ├── inventory
   ├── module_utils
   │   ├── __init__.py
   │   └── myos
   │       ├── __init__.py
   │       ├── argspec
   │       │   ├── __init__.py
   │       │   ├── facts
   │       │   │   ├── __init__.py
   │       │   │   └── facts.py
   │       │   └── interfaces
   │       │       ├── __init__.py
   │       │       └── interfaces.py
   │       ├── config
   │       │   ├── __init__.py
   │       │   ├── base.py
   │       │   └── interfaces
   │       │       ├── __init__.py
   │       │       └── interfaces.py
   │       ├── facts
   │       │   ├── __init__.py
   │       │   ├── base.py
   │       │   ├── facts.py
   │       │   └── interfaces
   │       │       ├── __init__.py
   │       │       └── interfaces.py
   │       └── utils
   │           ├── __init__.py
   │           └── utils.py
   └── modules
       ├── __init__.py
       ├── iosxr_facts.py
       └──iosxr_interfaces.py
``` 