### PR TITLE
IOS interface model

### DIFF
--- a/models/ios/interfaces/deleted_example_01.txt
+++ b/models/ios/interfaces/deleted_example_01.txt
@@ -21,7 +21,7 @@
 #  duplex full
 #  speed 1000
 
-- name: Delete IOS interfaces as in given arguments
+- name: Delete attributes of given interfaces (Note: This won't delete the interface itself)
   ios_interfaces:
     config:
       - name: GigabitEthernet0/2

--- a/models/ios/interfaces/deleted_example_01.txt
+++ b/models/ios/interfaces/deleted_example_01.txt
@@ -1,12 +1,46 @@
 # Using Deleted
 
+# Before state:
+# -------------
+#
+# vios#show running-config | section ^interface
+# interface GigabitEthernet0/1
+#  no ip address
+#  duplex auto
+#  speed auto
+# interface GigabitEthernet0/2
+#  description Configured and Overridden by Ansible Network
+#  no ip address
+#  duplex auto
+#  speed 1000
+# interface GigabitEthernet0/3
+#  description Configured and Replaced by Ansible Network
+#  mtu 2500
+#  no ip address
+#  shutdown
+#  duplex full
+#  speed 1000
+
 - name: Delete IOS interfaces as in given arguments
   ios_interfaces:
     config:
       - name: GigabitEthernet0/2
-        description: 'Configured by Ansible'
       - name: GigabitEthernet0/3
-        description: 'Configured by Ansible Network'
-        mtu: 1800
     operation: deleted
 
+# After state:
+# -------------
+#
+# vios#show running-config | section ^interface
+# interface GigabitEthernet0/1
+#  no ip address
+#  duplex auto
+#  speed auto
+# interface GigabitEthernet0/2
+#  no ip address
+#  duplex auto
+#  speed auto
+# interface GigabitEthernet0/3
+#  no ip address
+#  duplex auto
+#  speed auto

--- a/models/ios/interfaces/deleted_example_01.txt
+++ b/models/ios/interfaces/deleted_example_01.txt
@@ -1,0 +1,12 @@
+# Using Deleted
+
+- name: Delete IOS interfaces as in given arguments
+  ios_interfaces:
+    config:
+      - name: GigabitEthernet0/2
+        description: 'Configured by Ansible'
+      - name: GigabitEthernet0/3
+        description: 'Configured by Ansible Network'
+        mtu: 1800
+    operation: deleted
+

--- a/models/ios/interfaces/ios_interface.yaml
+++ b/models/ios/interfaces/ios_interface.yaml
@@ -1,0 +1,84 @@
+generator_version: 1.0
+metadata:
+  version: 1.1
+  status:
+  - preview
+  supported_by:
+  - 'Ansible Network'
+  copyright_str: Copyright 2019 Red Hat
+  license: gpl-3.0.txt
+info:
+  network_os: ios
+  resource: interfaces
+  version_added: 2.9
+  short_description: 'Manage Interface on Cisco IOS network devices.'
+  description:
+  - Manage Interface on Cisco IOS network devices.
+  authors:
+  - Sumit Jaiswal (@justjais)
+  extends_documentation_fragment: ios
+  notes:
+    - Tested against IOS Version 15.6(3)M2 on VIRL
+schema:
+  type: object
+  description: The schema used for the argspec and docstring
+  properties:
+    config:
+      type: array
+      description: The provided configuration
+      items:
+        $ref: '#/definitions/config_dict'
+    state:
+      $ref: '#/definitions/state'
+
+definitions:
+  config_dict:
+    description:
+    - The some_dict.
+    type: object
+    properties:
+      name:
+        description:
+        - Name of interface, i.e. GigabitEthernet0/2, loopback999.
+        type: str
+        required: true
+      description:
+        description:
+        - Description of Interface.
+        type: str
+      enabled:
+        description:
+        - Interface link status.
+        type: bool
+        default: true
+      speed:
+        description:
+        - Interface link speed. Applicable for ethernet interface only.
+        type: str
+      mtu:
+        description:
+        - Maximum size of transmit packet. Must be an number between 64 and 9600.
+          Applicable for Ethernet interface only.
+        type: str
+      duplex:
+        description:
+        - Interface link status. Applicable for ethernet interface only.
+        type: str
+        default: auto
+        choices: ['full', 'half', 'auto']
+
+  state:
+    description:
+    - The state the configuration should be left in
+    type: str
+    enum:
+    - merged
+    - replaced
+    - overridden
+    - deleted
+    default: merged
+examples:
+- merged_example_01.txt
+- replaced_example_01.txt
+- overridden_example_01.txt
+- deleted_example_01.txt

--- a/models/ios/interfaces/ios_interface.yaml
+++ b/models/ios/interfaces/ios_interface.yaml
@@ -11,9 +11,9 @@ info:
   network_os: ios
   resource: interfaces
   version_added: 2.9
-  short_description: 'Manage Interface on Cisco IOS network devices.'
+  short_description: 'Manages interface attributes of Cisco IOS network devices'
   description:
-  - Manage Interface on Cisco IOS network devices.
+  - This module manages the interface attributes of Cisco IOS network devices.
   authors:
   - Sumit Jaiswal (@justjais)
   extends_documentation_fragment: ios
@@ -34,35 +34,36 @@ schema:
 definitions:
   config_dict:
     description:
-    - The some_dict.
+    - A dictionary of interface options
     type: object
     properties:
       name:
         description:
-        - Name of interface, i.e. GigabitEthernet0/2, loopback999.
+        - Full name of interface, e.g. GigabitEthernet0/2, loopback999.
         type: str
         required: true
       description:
         description:
-        - Description of Interface.
+        - Interface description.
         type: str
-      enabled:
+      enable:
         description:
-        - Interface link status.
+        - Administrative state of the interface.
+        - Set the value to C(true) to administratively enable the interface or C(false) to disable it.
         type: bool
         default: true
       speed:
         description:
-        - Interface link speed. Applicable for ethernet interface only.
+        - Interface link speed. Applicable for Ethernet interfaces only.
         type: str
       mtu:
         description:
-        - Maximum size of transmit packet. Must be an number between 64 and 9600.
-          Applicable for Ethernet interface only.
+        - MTU for a specific interface. Must be a number between 64 and 9600.
+          Applicable for Ethernet interfaces only.
         type: str
       duplex:
         description:
-        - Interface link status. Applicable for ethernet interface only.
+        - Interface link status. Applicable for Ethernet interfaces only.
         type: str
         default: auto
         choices: ['full', 'half', 'auto']

--- a/models/ios/interfaces/ios_interface.yaml
+++ b/models/ios/interfaces/ios_interface.yaml
@@ -1,85 +1,72 @@
-generator_version: 1.0
-metadata:
-  version: 1.1
-  status:
-  - preview
-  supported_by:
-  - 'Ansible Network'
-  copyright_str: Copyright 2019 Red Hat
-  license: gpl-3.0.txt
-info:
-  network_os: ios
-  resource: interfaces
+---
+GENERATOR_VERSION: '1.0'
+
+ANSIBLE_METADATA: |
+    {
+      'metadata_version': '1.1',
+      'status': ['preview'],
+      'supported_by': 'network'
+    }
+NETWORK_OS: ios
+RESOURCE: interfaces
+COPYRIGHT: Copyright 2019 Red Hat
+
+DOCUMENTATION: |
+  module: ios_interfaces
   version_added: 2.9
-  short_description: 'Manages interface attributes of Cisco IOS network devices'
-  description:
-  - This module manages the interface attributes of Cisco IOS network devices.
-  authors:
-  - Sumit Jaiswal (@justjais)
-  extends_documentation_fragment: ios
-  notes:
-    - Tested against IOS Version 15.6(3)M2 on VIRL
-schema:
-  type: object
-  description: The schema used for the argspec and docstring
-  properties:
+  short_description: Manages interface attributes of Cisco IOS network devices
+  description: This module manages the interface attributes of Cisco IOS network devices.
+  author: Sumit Jaiswal (@justjais)
+  options:
     config:
-      type: array
-      description: The provided configuration
-      items:
-        $ref: '#/definitions/config_dict'
+      description: A dictionary of interface options
+      type: list
+      elements: dict
+      suboptions:
+        name:
+          description:
+          - Full name of interface, e.g. GigabitEthernet0/2, loopback999.
+          type: str
+          required: True
+        description:
+          description:
+          - Interface description.
+          type: str
+        enable:
+          description:
+          - Administrative state of the interface.
+          - Set the value to C(true) to administratively enable the interface or C(false) to disable it.
+          type: bool
+          default: true
+        speed:
+          description:
+          - Interface link speed. Applicable for Ethernet interfaces only.
+          type: str
+        mtu:
+          description:
+          - MTU for a specific interface. Must be a number between 64 and 9600.
+            Applicable for Ethernet interfaces only.
+          type: str
+        duplex:
+          default: automatic
+          description:
+          - Interface link status. Applicable for Ethernet interfaces only, either in half duplex,
+            full duplex or in automatic state which negotiates the duplex automatically.
+          type: str
+          default: auto
+          choices: ['full', 'half', 'auto']
     state:
-      $ref: '#/definitions/state'
-
-definitions:
-  config_dict:
-    description:
-    - A dictionary of interface options
-    type: object
-    properties:
-      name:
-        description:
-        - Full name of interface, e.g. GigabitEthernet0/2, loopback999.
-        type: str
-        required: true
+      choices:
+      - merged
+      - replaced
+      - overridden
+      - deleted
+      default: merged
       description:
-        description:
-        - Interface description.
-        type: str
-      enable:
-        description:
-        - Administrative state of the interface.
-        - Set the value to C(true) to administratively enable the interface or C(false) to disable it.
-        type: bool
-        default: true
-      speed:
-        description:
-        - Interface link speed. Applicable for Ethernet interfaces only.
-        type: str
-      mtu:
-        description:
-        - MTU for a specific interface. Must be a number between 64 and 9600.
-          Applicable for Ethernet interfaces only.
-        type: str
-      duplex:
-        description:
-        - Interface link status. Applicable for Ethernet interfaces only.
-        type: str
-        default: auto
-        choices: ['full', 'half', 'auto']
-
-  state:
-    description:
-    - The state the configuration should be left in
-    type: str
-    enum:
-    - merged
-    - replaced
-    - overridden
-    - deleted
-    default: merged
-examples:
-- merged_example_01.txt
-- replaced_example_01.txt
-- overridden_example_01.txt
-- deleted_example_01.txt
+      - The state the configuration should be left in
+      type: str
+EXAMPLES:
+  - deleted_example_01.txt
+  - merged_example_01.txt
+  - overridden_example_01.txt
+  - replaced_example_01.txt

--- a/models/ios/interfaces/merged_example_01.txt
+++ b/models/ios/interfaces/merged_example_01.txt
@@ -1,13 +1,56 @@
 # Using merged
 
-- name: Configure Ethernet interfaces
+# Before state:
+# -------------
+#
+# vios#show running-config | section ^interface
+# interface GigabitEthernet0/1
+#  description Configured by Ansible
+#  no ip address
+#  duplex auto
+#  speed auto
+# interface GigabitEthernet0/2
+#  description This is test
+#  no ip address
+#  duplex auto
+#  speed 1000
+# interface GigabitEthernet0/3
+#  no ip address
+#  duplex auto
+#  speed auto
+
+- name: Merge provided configuration with device configuration
   ios_interfaces:
     config:
       - name: GigabitEthernet0/2
-        description: 'Configured by Ansible'
+        description: 'Configured and Merged by Ansible Network'
         enabled: True
       - name: GigabitEthernet0/3
-        description: 'Configured by Ansible Network'
+        description: 'Configured and Merged by Ansible Network'
+        mtu: 2800
         enabled: False
+        speed: 100
 	duplex: full
     operation: merged
+
+# After state:
+# ------------
+#
+# vios#show running-config | section ^interface
+# interface GigabitEthernet0/1
+#  description Configured by Ansible
+#  no ip address
+#  duplex auto
+#  speed auto
+# interface GigabitEthernet0/2
+#  description Configured and Merged by Ansible Network
+#  no ip address
+#  duplex auto
+#  speed 1000
+# interface GigabitEthernet0/3
+#  description Configured and Merged by Ansible Network
+#  mtu 2800
+#  no ip address
+#  shutdown
+#  duplex full
+#  speed 100

--- a/models/ios/interfaces/merged_example_01.txt
+++ b/models/ios/interfaces/merged_example_01.txt
@@ -1,0 +1,13 @@
+# Using merged
+
+- name: Configure Ethernet interfaces
+  ios_interfaces:
+    config:
+      - name: GigabitEthernet0/2
+        description: 'Configured by Ansible'
+        enabled: True
+      - name: GigabitEthernet0/3
+        description: 'Configured by Ansible Network'
+        enabled: False
+	duplex: full
+    operation: merged

--- a/models/ios/interfaces/override_example_01.txt
+++ b/models/ios/interfaces/override_example_01.txt
@@ -1,15 +1,57 @@
-
 # Using overridden
 
-- name: Override interfaces
+# Before state:
+# -------------
+#
+# vios#show running-config | section ^interface#
+# interface GigabitEthernet0/1
+#  description Configured by Ansible
+#  no ip address
+#  duplex auto
+#  speed auto
+# interface GigabitEthernet0/2
+#  description This is test
+#  no ip address
+#  duplex auto
+#  speed 1000
+# interface GigabitEthernet0/3
+#  description Configured by Ansible
+#  mtu 2800
+#  no ip address
+#  shutdown
+#  duplex full
+#  speed 100
+
+- name: Override device configuration of all interfaces with provided configuration
   ios_interfaces:
     config:
       - name: GigabitEthernet0/2
-        description: 'Configured by Ansible'
-        enabled: True
-        duplex: auto
-      - name: GigabitEthernet0/3
-        description: 'Configured by Ansible Network'
-        enabled: False
+        description: 'Configured and Overridden by Ansible Network'
         speed: 1000
+      - name: GigabitEthernet0/3
+        description: 'Configured and Overridden by Ansible Network'
+        enabled: False
+        duplex: full
+        mtu: 2000
     operation: overridden
+
+# After state:
+# -------------
+#
+# vios#show running-config | section ^interface
+# interface GigabitEthernet0/1
+#  no ip address
+#  duplex auto
+#  speed auto
+# interface GigabitEthernet0/2
+#  description Configured and Overridden by Ansible Network
+#  no ip address
+#  duplex auto
+#  speed 1000
+# interface GigabitEthernet0/3
+#  description Configured and Overridden by Ansible Network
+#  mtu 2000
+#  no ip address
+#  shutdown
+#  duplex full
+#  speed 100

--- a/models/ios/interfaces/override_example_01.txt
+++ b/models/ios/interfaces/override_example_01.txt
@@ -1,0 +1,15 @@
+
+# Using overridden
+
+- name: Override interfaces
+  ios_interfaces:
+    config:
+      - name: GigabitEthernet0/2
+        description: 'Configured by Ansible'
+        enabled: True
+        duplex: auto
+      - name: GigabitEthernet0/3
+        description: 'Configured by Ansible Network'
+        enabled: False
+        speed: 1000
+    operation: overridden

--- a/models/ios/interfaces/replaced_example_01.txt
+++ b/models/ios/interfaces/replaced_example_01.txt
@@ -1,14 +1,53 @@
 # Using replaced
 
-- name: Configure following interfaces and replace their existing config
+# Before state:
+# -------------
+#
+# vios#show running-config | section ^interface
+# interface GigabitEthernet0/1
+#  no ip address
+#  duplex auto
+#  speed auto
+# interface GigabitEthernet0/2
+#  description Configured by Ansible Network
+#  no ip address
+#  duplex auto
+#  speed 1000
+# interface GigabitEthernet0/3
+#  mtu 2000
+#  no ip address
+#  shutdown
+#  duplex full
+#  speed 100
+
+- name: Replaces device configuration of listed interfaces with provided configuration
   ios_interfaces:
     config:
-      - name: GigabitEthernet0/2
-        description: Configured by Ansible
-        enabled: True
-	mtu: 2000
       - name: GigabitEthernet0/3
-        description: 'Configured by Ansible Network'
+        description: 'Configured and Replaced by Ansible Network'
         enabled: False
 	duplex: auto
+        mtu: 2500
+        speed: 1000
     operation: replaced
+
+# After state:
+# -------------
+#
+# vios#show running-config | section ^interface
+# interface GigabitEthernet0/1
+#  no ip address
+#  duplex auto
+#  speed auto
+# interface GigabitEthernet0/2
+#  description Configured by Ansible Network
+#  no ip address
+#  duplex auto
+#  speed 1000
+# interface GigabitEthernet0/3
+#  description Configured and Replaced by Ansible Network
+#  mtu 2500
+#  no ip address
+#  shutdown
+#  duplex full
+#  speed 1000

--- a/models/ios/interfaces/replaced_example_01.txt
+++ b/models/ios/interfaces/replaced_example_01.txt
@@ -1,0 +1,14 @@
+# Using replaced
+
+- name: Configure following interfaces and replace their existing config
+  ios_interfaces:
+    config:
+      - name: GigabitEthernet0/2
+        description: Configured by Ansible
+        enabled: True
+	mtu: 2000
+      - name: GigabitEthernet0/3
+        description: 'Configured by Ansible Network'
+        enabled: False
+	duplex: auto
+    operation: replaced


### PR DESCRIPTION
**Docstring**
```
#!/usr/bin/python
# -*- coding: utf-8 -*-
# Copyright 2019 Red Hat Inc.
# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

##############################################
################# WARNING ####################
##############################################
###
### This file is auto generated by the resource
###   module builder playbook.
###
### Do not edit this file manually.
###
### Changes to this file will be over written
###   by the resource module builder.
###
### Changes should be made in the model used to
###   generate this file or in the resource module
###   builder template.
###
##############################################
##############################################
##############################################

"""
The module file for ios_interfaces
"""

from __future__ import absolute_import, division, print_function
from ansible.module_utils.basic import AnsibleModule
from ansible_collections.ansible_network.network.plugins.module_utils. \
     ios.config.interfaces.interfaces import Interfaces

ANSIBLE_METADATA = {'metadata_version': '1.1',
                    'status': [u'preview'],
                    'supported_by': [u'Ansible Network']}


DOCUMENTATION = """
---
module: ios_interfaces
version_added: 2.9
short_description: Manage Interface on Cisco IOS network devices.
description: Manage Interface on Cisco IOS network devices.
author: [u'Sumit Jaiswal (@justjais)']
options:
  config:
    description: The provided configuration
    suboptions:
      name:
        description:
        - Name of interface, i.e. GigabitEthernet0/2, loopback999.
        type: str
        required: true
      description:
        description:
        - Description of Interface.
        type: str
      enabled:
        description:
        - Interface link status.
        type: bool
        default: true
      speed:
        description:
        - Interface link speed. Applicable for ethernet interface only.
        type: str
      mtu:
        description:
        - Maximum size of transmit packet. Must be an number between 64 and 9600.
          Applicable for Ethernet interface only.
        type: str
      duplex:
        description:
        - Interface link status. Applicable for ethernet interface only.
        type: str
        default: auto
        choices: ['full', 'half', 'auto']
  state:
    choices:
    - merged
    - replaced
    - overridden
    - deleted
    default: merged
    description:
    - The state the configuration should be left in
    type: str
"""

EXAMPLES = """
---

# Using merged

- name: Configure Ethernet interfaces
  ios_interfaces:
    config:
      - name: GigabitEthernet0/2
        description: 'Configured by Ansible'
        enabled: True
      - name: GigabitEthernet0/3
        description: 'Configured by Ansible Network'
        enabled: False
        duplex: full
    operation: merged

# Using replaced

- name: Configure following interfaces and replace their existing config
  ios_interfaces:
    config:
      - name: GigabitEthernet0/2
        description: Configured by Ansible
        enabled: True
        mtu: 2000
      - name: GigabitEthernet0/3
        description: 'Configured by Ansible Network'
        enabled: False
        duplex: auto
    operation: replaced

# Using overridden

- name: Override interfaces
  ios_interfaces:
    config:
      - name: GigabitEthernet0/2
        description: 'Configured by Ansible'
        enabled: True
        duplex: auto
      - name: GigabitEthernet0/3
        description: 'Configured by Ansible Network'
        enabled: False
        speed: 1000
    operation: overridden

# Using deleted

- name: Delete IOS interfaces as in given arguments
  ios_interfaces:
    config:
      - name: GigabitEthernet0/2
        description: 'Configured by Ansible'
      - name: GigabitEthernet0/3
        description: 'Configured by Ansible Network'
        mtu: 1800
    operation: deleted

"""
```
**Layout**
```
plugins
   ├── action
   ├── filter
   ├── inventory
   ├── module_utils
   │   ├── __init__.py
   │   ├── ios
   │   │   ├── __init__.py
   │   │   ├── argspec
   │   │   │   ├── __init__.py
   │   │   │   ├── facts
   │   │   │   │   ├── __init__.py
   │   │   │   │   └── facts.py
   │   │   │   └── interfaces
   │   │   │       ├── __init__.py
   │   │   │       └── interfaces.py
   │   │   ├── config
   │   │   │   ├── __init__.py
   │   │   │   ├── base.py
   │   │   │   └── interfaces
   │   │   │       ├── __init__.py
   │   │   │       └── interfaces.py
   │   │   ├── facts
   │   │   │   ├── __init__.py
   │   │   │   ├── base.py
   │   │   │   ├── facts.py
   │   │   │   └── interfaces
   │   │   │       ├── __init__.py
   │   │   │       └── interfaces.py
   │   │   └── utils
   │   │       ├── __init__.py
   │   │       └── utils.py
   │   └── network
   │       ├── __init__.py
   │       └── argspec
   │           ├── __init__.py
   │           └── base.py
   └── modules
       ├── __init__.py
       ├── ios_facts.py
       └── ios_interfaces.py
```