### PR TITLE
Add junos_interfaces model

### DIFF
--- a/models/junos/interfaces/deleted_example_01.txt
+++ b/models/junos/interfaces/deleted_example_01.txt
@@ -1,0 +1,36 @@
+# Using deleted
+
+# Before state:
+# -------------
+# user@junos01# show interfaces
+# ge-0/0/1 {
+#    description "Configured by Ansible-1";
+#    speed 1g;
+#    mtu 1800
+# }
+# ge-0/0/2 {
+#    description "Configured by Ansible-2";
+#    ether-options {
+#        auto-negotiation;
+#    }
+# }
+
+- name: Delete given options for the interface (Note: This won't delete the interface itself if any other values are configured for interface)
+  junos_interfaces:
+    config:
+      - name: ge-0/0/1
+        description: 'Configured by Ansible-1'
+        speed: 1g
+        mtu: 1800
+      - name: ge-0/0/2
+        description: 'Configured by Ansible -2'
+    operation: deleted
+
+# After state:
+# ------------
+# user@junos01# show interfaces
+# ge-0/0/2 {
+#    ether-options {
+#        auto-negotiation;
+#    }
+# }

--- a/models/junos/interfaces/junos_interfaces.yml
+++ b/models/junos/interfaces/junos_interfaces.yml
@@ -1,0 +1,99 @@
+---
+generator_version: 1.0
+metadata:
+  vesion: 1.1
+  status:
+  - preview
+  supported_by:
+  - 'Ansible Network'
+  copyright_str: Copyright 2019 Red Hat
+  license: gpl-3.0.txt
+info:
+  network_os: junos
+  resource: interfaces
+  version_added: 2.9
+  short_description: "This module provides configuration management of Interfaces on Juniper JUNOS network devices."
+  description:
+  - "Manage Interface on Juniper JUNOS network devices."
+  authors:
+  - Ganesh Nalawade (@ganeshrn)
+  notes:
+    - Tested against vSRX JUNOS version 17.3R1.10.
+schema:
+  type: object
+  description: The schema used for the argspec and docstring
+  properties:
+    config:
+      type: array
+      description: The provided configuration
+      items:
+        $ref: '#/definitions/config_dict'
+    state:
+      $ref: '#/definitions/state'
+
+definitions:
+  config_dict:
+    description:
+    - Specifies interfaces related configurations.
+    type: object
+    properties:
+      name:
+        description:
+        - The complete name of the interface to be managed, the interface name
+          should be in same format as seen in the running configurtion.
+        type: str
+        required: true
+      description:
+        description:
+        - This option represnets a text description of the interface.
+        type: str
+      enable:
+        description:
+        - This option takes a boolean value which controls state of the interface.
+          If value is C(True) the inerfaces is enabled, if value is C(False) interface
+          is disabled.
+        type: bool
+        default: true
+      speed:
+        description:
+        - This option configures the link speed for the given interface I(name).
+        type: str
+      mtu:
+        description:
+        - This option configures the maximum transmit package size for the given interface I(name).
+        type: str
+      duplex:
+        description:
+        - This option configures the link mode for given interface I(name), the link can be configured
+          either in half duplex, full duplex or in automatic state which negotiates the duplex automatically.
+        type: str
+        default: automatic
+        choices: ['automatic', 'full-duplex', 'half-duplex']
+      hold_time:
+        description:
+        - This option configures the hold time for given interface name.
+        type: dict
+        suboptions:
+          - down:
+              description:
+              - This options represents link down hold time in milliseconds.
+              type: int
+          - up:
+              description:
+              - This options represents link up hold time in milliseconds.
+              type: int
+  state:
+    description:
+    - The state the configuration should be left in
+    type: str
+    enum:
+    - merged
+    - replaced
+    - overridden
+    - deleted
+    default: merged
+examples:
+- merged_example_01.txt
+- replaced_example_01.txt
+- overridden_example_01.txt
+- deleted_example_01.txt

--- a/models/junos/interfaces/merged_example_01.txt
+++ b/models/junos/interfaces/merged_example_01.txt
@@ -1,0 +1,35 @@
+
+# Using merged
+
+# Before state:
+# -------------
+# user@junos01# show interfaces
+# ge-0/0/1 {
+#    description "test interface";
+#    speed 1g;
+# }
+
+- name: "Configure interface values (default operation is merge)"
+  junos_interfaces:
+    config:
+      - name: ge-0/0/1
+        description: 'Configured by Ansible-1'
+        enable: True
+	    mtu: 1800
+      - name: ge-0/0/2
+        description: 'Configured by Ansible-2'
+        enable: False
+    operation: merged
+
+# After state:
+# ------------
+# user@junos01# show interfaces
+# ge-0/0/1 {
+#    description "Configured by Ansible-1";
+#    speed 1g;
+#    mtu 1800
+# }
+# ge-0/0/2 {
+#    disable;
+#    description "Configured by Ansible-2";
+# }

--- a/models/junos/interfaces/overridden_example_01.txt
+++ b/models/junos/interfaces/overridden_example_01.txt
@@ -1,0 +1,44 @@
+
+# Using overriden
+
+# Before state:
+# -------------
+# user@junos01# show interfaces
+# ge-0/0/1 {
+#    description "Configured by Ansible-1";
+#    speed 1g;
+#    mtu 1800
+# }
+# ge-0/0/2 {
+#    disable;
+#    description "Configured by Ansible-2";
+#    ether-options {
+#        auto-negotiation;
+#    }
+# }
+# ge-0/0/11 {
+#    description "Configured by Ansible-11";
+# }
+
+- name: Override interfaces
+  junos_interfaces:
+    config:
+      - name: ge-0/0/2
+        description: 'Configured by Ansible-2'
+        enable: False
+	    mtu: 2800
+      - name: ge-0/0/3
+        description: 'Configured by Ansible-3'
+    operation: overriden
+
+# After state:
+# ------------
+# user@junos01# show interfaces
+# ge-0/0/2 {
+#    disable;
+#    description "Configured by Ansible-2";
+#    mtu 2800
+# }
+# ge-0/0/3 {
+#    description "Configured by Ansible-3";
+# }

--- a/models/junos/interfaces/replaced_example_01.txt
+++ b/models/junos/interfaces/replaced_example_01.txt
@@ -1,0 +1,54 @@
+
+# Using replaced
+
+# Before state:
+# -------------
+# user@junos01# show interfaces
+# ge-0/0/1 {
+#    description "Configured by Ansible-1";
+#    speed 1g;
+#    mtu 1800
+# }
+# ge-0/0/2 {
+#    disable;
+#    mtu 1800;
+#    speed 1g;
+#    description "Configured by Ansible-2";
+#    ether-options {
+#        auto-negotiation;
+#    }
+# }
+# ge-0/0/11 {
+#    description "Configured by Ansible-11";
+# }
+
+- name: Override interfaces
+  junos_interfaces:
+    config:
+      - name: ge-0/0/2
+        description: 'Configured by Ansible-2'
+        enable: False
+	    mtu: 2800
+      - name: ge-0/0/3
+        description: 'Configured by Ansible-3'
+    operation: replaced
+
+# After state:
+# ------------
+# user@junos01# show interfaces
+# ge-0/0/1 {
+#    description "Configured by Ansible-1";
+#    speed 1g;
+#    mtu 1800
+# }
+# ge-0/0/2 {
+#    disable;
+#    description "Configured by Ansible-2";
+#    mtu 2800
+# }
+# ge-0/0/3 {
+#    description "Configured by Ansible-3";
+# }
+# ge-0/0/11 {
+#    description "Configured by Ansible-11";
+# }


### PR DESCRIPTION
Module content
```
#!/usr/bin/python
# -*- coding: utf-8 -*-
# Copyright 2019 Red Hat
# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

##############################################
################# WARNING ####################
##############################################
###
### This file is auto generated by the resource
###   module builder playbook.
###
### Do not edit this file manually.
###
### Changes to this file will be over written
###   by the resource module builder.
###
### Changes should be made in the model used to
###   generate this file or in the resource module
###   builder template.
###
##############################################
##############################################
##############################################

"""
The module file for junos_interfaces
"""

from __future__ import absolute_import, division, print_function
from ansible.module_utils.basic import AnsibleModule
from ansible.module_utils. \
     junos.config.interfaces.interfaces import Interfaces

ANSIBLE_METADATA = {'metadata_version': '1.1',
                    'status': [u'preview'],
                    'supported_by': [u'Ansible Network']}


DOCUMENTATION = """
---
module: junos_interfaces
version_added: 2.9
short_description: This module provides configuration management of Interfaces on Juniper JUNOS network devices.
description: [u'Manage Interface on Juniper JUNOS network devices.']
author: [u'Ganesh Nalawade (@ganeshrn)']
options:
  config:
    description: The provided configuration
    suboptions:
      description:
        description:
        - This option represnets a text description of the interface.
        type: str
      duplex:
        default: automatic
        description:
        - This option configures the link mode for given interface I(name), the link
          can be configured either in half duplex, full duplex or in automatic state
          which negotiates the duplex automatically.
        type: str
      enable:
        default: true
        description:
        - This option takes a boolean value which controls state of the interface.
          If value is C(True) the inerfaces is enabled, if value is C(False) interface
          is disabled.
        type: bool
      hold_time:
        description:
        - This option configures the hold time for given interface name.
      mtu:
        description:
        - This option configures the maximum transmit package size for the given interface
          I(name).
        type: str
      name:
        description:
        - The complete name of the interface to be managed, the interface name should
          be in same format as seen in the running configurtion.
        type: str
      speed:
        description:
        - This option configures the link speed for the given interface I(name).
        type: str
  state:
    choices:
    - merged
    - replaced
    - overridden
    - deleted
    default: merged
    description:
    - The state the configuration should be left in
    type: str

"""

EXAMPLES = """
---

# Using merged

# Before state:
# -------------
# user@junos01# show interfaces
# ge-0/0/1 {
#    description "test interface";
#    speed 1g;
# }

- name: "Configure interface values (default operation is merge)"
  junos_interfaces:
    config:
      - name: ge-0/0/1
        description: 'Configured by Ansible-1'
        enable: True
	    mtu: 1800
      - name: ge-0/0/2
        description: 'Configured by Ansible-2'
        enable: False
    operation: merged

# After state:
# ------------
# user@junos01# show interfaces
# ge-0/0/1 {
#    description "Configured by Ansible-1";
#    speed 1g;
#    mtu 1800
# }
# ge-0/0/2 {
#    disable;
#    description "Configured by Ansible-2";
# }

# Using replaced

# Before state:
# -------------
# user@junos01# show interfaces
# ge-0/0/1 {
#    description "Configured by Ansible-1";
#    speed 1g;
#    mtu 1800
# }
# ge-0/0/2 {
#    disable;
#    mtu 1800;
#    speed 1g;
#    description "Configured by Ansible-2";
#    ether-options {
#        auto-negotiation;
#    }
# }
# ge-0/0/11 {
#    description "Configured by Ansible-11";
# }

- name: Override interfaces
  junos_interfaces:
    config:
      - name: ge-0/0/2
        description: 'Configured by Ansible-2'
        enable: False
	    mtu: 2800
      - name: ge-0/0/3
        description: 'Configured by Ansible-3'
    operation: replaced

# After state:
# ------------
# user@junos01# show interfaces
# ge-0/0/1 {
#    description "Configured by Ansible-1";
#    speed 1g;
#    mtu 1800
# }
# ge-0/0/2 {
#    disable;
#    description "Configured by Ansible-2";
#    mtu 2800
# }
# ge-0/0/3 {
#    description "Configured by Ansible-3";
# }
# ge-0/0/11 {
#    description "Configured by Ansible-11";
# }

# Using overriden

# Before state:
# -------------
# user@junos01# show interfaces
# ge-0/0/1 {
#    description "Configured by Ansible-1";
#    speed 1g;
#    mtu 1800
# }
# ge-0/0/2 {
#    disable;
#    description "Configured by Ansible-2";
#    ether-options {
#        auto-negotiation;
#    }
# }
# ge-0/0/11 {
#    description "Configured by Ansible-11";
# }

- name: Override interfaces
  junos_interfaces:
    config:
      - name: ge-0/0/2
        description: 'Configured by Ansible-2'
        enable: False
	    mtu: 2800
      - name: ge-0/0/3
        description: 'Configured by Ansible-3'
    operation: overriden

# After state:
# ------------
# user@junos01# show interfaces
# ge-0/0/2 {
#    disable;
#    description "Configured by Ansible-2";
#    mtu 2800
# }
# ge-0/0/3 {
#    description "Configured by Ansible-3";
# }
# Using deleted

# Before state:
# -------------
# user@junos01# show interfaces
# ge-0/0/1 {
#    description "Configured by Ansible-1";
#    speed 1g;
#    mtu 1800
# }
# ge-0/0/2 {
#    description "Configured by Ansible-2";
#    ether-options {
#        auto-negotiation;
#    }
# }

- name: Delete given options for the interface (Note: This won't delete the interface itself if any other values are configured for interface)
  junos_interfaces:
    config:
      - name: ge-0/0/1
        description: 'Configured by Ansible-1'
        speed: 1g
        mtu: 1800
      - name: ge-0/0/2
        description: 'Configured by Ansible -2'
    operation: deleted

# After state:
# ------------
# user@junos01# show interfaces
# ge-0/0/2 {
#    ether-options {
#        auto-negotiation;
#    }
# }
"""

RETURN = """
before:
  description: The configuration prior to the model invocation.
  returned: always
  sample: The configuration returned will always be in the same format of the parameters above.
after:
  description: The resulting configuration model invocation.
  returned: when changed
  sample: The configuration returned will always be in the same format of the parameters above.
commands:
  description: The set of commands pushed to the remote device.
  returned: always
  type: list
  sample: ['command 1', 'command 2', 'command 3']
"""


def main():
    """
    Main entry point for module execution

    :returns: the result form module invocation
    """
    module = AnsibleModule(argument_spec=Interfaces.argument_spec,
                           supports_check_mode=True)

    result = Interfaces(module).execute_module()
    module.exit_json(**result)

if __name__ == '__main__':
    main()
```