### PR TITLE
Adding ios_l2_interfaces model in new format

### DIFF
--- a/ios/l2_interfaces/deleted_example_01.txt
+++ b/ios/l2_interfaces/deleted_example_01.txt
@@ -1,0 +1,116 @@
+# Using Deleted
+
+# Before state:
+# -------------
+#
+# viosl2#show interfaces switchport
+# Name: Gi0/1
+# Switchport: Enabled
+# Administrative Mode: static access
+# Operational Mode: static access
+# Administrative Trunking Encapsulation: negotiate
+# Operational Trunking Encapsulation: native
+# Negotiation of Trunking: Off
+# Access Mode VLAN: 20 (VLAN0020)
+# Trunking Native Mode VLAN: 1 (default)
+# Administrative Native VLAN tagging: enabled
+# Voice VLAN: none
+# Administrative private-vlan host-association: none
+# Administrative private-vlan mapping: none
+# Administrative private-vlan trunk native VLAN: none
+# Administrative private-vlan trunk Native VLAN tagging: enabled
+# Administrative private-vlan trunk encapsulation: dot1q
+# Administrative private-vlan trunk normal VLANs: none
+# Administrative private-vlan trunk associations: none
+# Administrative private-vlan trunk mappings: none
+# Operational private-vlan: none
+# Trunking VLANs Enabled: ALL
+# Pruning VLANs Enabled: 2-1001
+# Capture Mode Disabled
+# Capture VLANs Allowed: ALL
+#
+# Name: Gi0/2
+# Switchport: Enabled
+# Administrative Mode: trunk
+# Operational Mode: trunk
+# Administrative Trunking Encapsulation: dot1q
+# Operational Trunking Encapsulation: dot1q
+# Negotiation of Trunking: On
+# Access Mode VLAN: 10 (VLAN0010)
+# Trunking Native Mode VLAN: 20 (VLAN0020)
+# Administrative Native VLAN tagging: enabled
+# Voice VLAN: none
+# Administrative private-vlan host-association: none
+# Administrative private-vlan mapping: none
+# Administrative private-vlan trunk native VLAN: none
+# Administrative private-vlan trunk Native VLAN tagging: enabled
+# Administrative private-vlan trunk encapsulation: dot1q
+# Administrative private-vlan trunk normal VLANs: none
+# Administrative private-vlan trunk associations: none
+# Administrative private-vlan trunk mappings: none
+# Operational private-vlan: none
+# Trunking VLANs Enabled: ALL
+# Pruning VLANs Enabled: 2-1001
+# Capture Mode Disabled
+# Capture VLANs Allowed: ALL
+
+- name: Delete IOS L2 interfaces as in given arguments
+  ios_interfaces:
+    config:
+      - name: GigabitEthernet0/1
+      - name: GigabitEthernet0/2
+    operation: deleted
+
+# After state:
+# -------------
+#
+# viosl2#show interfaces switchport
+# Name: Gi0/1
+# Switchport: Enabled
+# Administrative Mode: dynamic auto
+# Operational Mode: static access
+# Administrative Trunking Encapsulation: negotiate
+# Operational Trunking Encapsulation: native
+# Negotiation of Trunking: Off
+# Access Mode VLAN: 1 (default)
+# Trunking Native Mode VLAN: 1 (default)
+# Administrative Native VLAN tagging: enabled
+# Voice VLAN: none
+# Administrative private-vlan host-association: none
+# Administrative private-vlan mapping: none
+# Administrative private-vlan trunk native VLAN: none
+# Administrative private-vlan trunk Native VLAN tagging: enabled
+# Administrative private-vlan trunk encapsulation: dot1q
+# Administrative private-vlan trunk normal VLANs: none
+# Administrative private-vlan trunk associations: none
+# Administrative private-vlan trunk mappings: none
+# Operational private-vlan: none
+# Trunking VLANs Enabled: ALL
+# Pruning VLANs Enabled: 2-1001
+# Capture Mode Disabled
+# Capture VLANs Allowed: ALL
+#
+# Name: Gi0/2
+# Switchport: Enabled
+# Administrative Mode: dynamic auto
+# Operational Mode: static access
+# Administrative Trunking Encapsulation: negotiate
+# Operational Trunking Encapsulation: native
+# Negotiation of Trunking: Off
+# Access Mode VLAN: 1 (default)
+# Trunking Native Mode VLAN: 1 (default)
+# Administrative Native VLAN tagging: enabled
+# Voice VLAN: none
+# Administrative private-vlan host-association: none 
+# Administrative private-vlan mapping: none 
+# Administrative private-vlan trunk native VLAN: none
+# Administrative private-vlan trunk Native VLAN tagging: enabled
+# Administrative private-vlan trunk encapsulation: dot1q
+# Administrative private-vlan trunk normal VLANs: none
+# Administrative private-vlan trunk associations: none
+# Administrative private-vlan trunk mappings: none
+# Operational private-vlan: none
+# Trunking VLANs Enabled: ALL
+# Pruning VLANs Enabled: 2-1001
+# Capture Mode Disabled
+# Capture VLANs Allowed: ALL#

--- a/ios/l2_interfaces/deleted_example_01.txt
+++ b/ios/l2_interfaces/deleted_example_01.txt
@@ -12,8 +12,10 @@
 # interface GigabitEthernet0/2
 #  description This is test
 #  switchport access vlan 20
+#  switchport trunk allowed vlan 20,40,60,80
 #  switchport trunk encapsulation dot1q
 #  switchport trunk native vlan 10
+#  switchport trunk pruning vlan 10
 #  switchport mode trunk
 #  media-type rj45
 #  negotiation auto
@@ -23,7 +25,7 @@
     config:
       - name: GigabitEthernet0/1
       - name: GigabitEthernet0/2
-    operation: deleted
+    state: deleted
 
 # After state:
 # -------------

--- a/ios/l2_interfaces/deleted_example_01.txt
+++ b/ios/l2_interfaces/deleted_example_01.txt
@@ -19,12 +19,15 @@
 #  switchport mode trunk
 #  media-type rj45
 #  negotiation auto
+# interface GigabitEthernet0/3.100
+#  encapsulation dot1Q 20
 
 - name: Delete IOS L2 interfaces as in given arguments
   ios_interfaces:
     config:
       - name: GigabitEthernet0/1
       - name: GigabitEthernet0/2
+      - name: GigabitEthernet0/3.100
     state: deleted
 
 # After state:
@@ -38,3 +41,5 @@
 #  description This is test
 #  media-type rj45
 #  negotiation auto
+# interface GigabitEthernet0/3.100
+

--- a/ios/l2_interfaces/deleted_example_01.txt
+++ b/ios/l2_interfaces/deleted_example_01.txt
@@ -3,56 +3,20 @@
 # Before state:
 # -------------
 #
-# viosl2#show interfaces switchport
-# Name: Gi0/1
-# Switchport: Enabled
-# Administrative Mode: static access
-# Operational Mode: static access
-# Administrative Trunking Encapsulation: negotiate
-# Operational Trunking Encapsulation: native
-# Negotiation of Trunking: Off
-# Access Mode VLAN: 20 (VLAN0020)
-# Trunking Native Mode VLAN: 1 (default)
-# Administrative Native VLAN tagging: enabled
-# Voice VLAN: none
-# Administrative private-vlan host-association: none
-# Administrative private-vlan mapping: none
-# Administrative private-vlan trunk native VLAN: none
-# Administrative private-vlan trunk Native VLAN tagging: enabled
-# Administrative private-vlan trunk encapsulation: dot1q
-# Administrative private-vlan trunk normal VLANs: none
-# Administrative private-vlan trunk associations: none
-# Administrative private-vlan trunk mappings: none
-# Operational private-vlan: none
-# Trunking VLANs Enabled: ALL
-# Pruning VLANs Enabled: 2-1001
-# Capture Mode Disabled
-# Capture VLANs Allowed: ALL
-#
-# Name: Gi0/2
-# Switchport: Enabled
-# Administrative Mode: trunk
-# Operational Mode: trunk
-# Administrative Trunking Encapsulation: dot1q
-# Operational Trunking Encapsulation: dot1q
-# Negotiation of Trunking: On
-# Access Mode VLAN: 10 (VLAN0010)
-# Trunking Native Mode VLAN: 20 (VLAN0020)
-# Administrative Native VLAN tagging: enabled
-# Voice VLAN: none
-# Administrative private-vlan host-association: none
-# Administrative private-vlan mapping: none
-# Administrative private-vlan trunk native VLAN: none
-# Administrative private-vlan trunk Native VLAN tagging: enabled
-# Administrative private-vlan trunk encapsulation: dot1q
-# Administrative private-vlan trunk normal VLANs: none
-# Administrative private-vlan trunk associations: none
-# Administrative private-vlan trunk mappings: none
-# Operational private-vlan: none
-# Trunking VLANs Enabled: ALL
-# Pruning VLANs Enabled: 2-1001
-# Capture Mode Disabled
-# Capture VLANs Allowed: ALL
+# viosl2#show running-config | section ^interface
+# interface GigabitEthernet0/1
+#  description Configured by Ansible
+#  switchport access vlan 20
+#  switchport mode access
+#  negotiation auto
+# interface GigabitEthernet0/2
+#  description This is test
+#  switchport access vlan 20
+#  switchport trunk encapsulation dot1q
+#  switchport trunk native vlan 10
+#  switchport mode trunk
+#  media-type rj45
+#  negotiation auto
 
 - name: Delete IOS L2 interfaces as in given arguments
   ios_interfaces:
@@ -64,53 +28,11 @@
 # After state:
 # -------------
 #
-# viosl2#show interfaces switchport
-# Name: Gi0/1
-# Switchport: Enabled
-# Administrative Mode: dynamic auto
-# Operational Mode: static access
-# Administrative Trunking Encapsulation: negotiate
-# Operational Trunking Encapsulation: native
-# Negotiation of Trunking: Off
-# Access Mode VLAN: 1 (default)
-# Trunking Native Mode VLAN: 1 (default)
-# Administrative Native VLAN tagging: enabled
-# Voice VLAN: none
-# Administrative private-vlan host-association: none
-# Administrative private-vlan mapping: none
-# Administrative private-vlan trunk native VLAN: none
-# Administrative private-vlan trunk Native VLAN tagging: enabled
-# Administrative private-vlan trunk encapsulation: dot1q
-# Administrative private-vlan trunk normal VLANs: none
-# Administrative private-vlan trunk associations: none
-# Administrative private-vlan trunk mappings: none
-# Operational private-vlan: none
-# Trunking VLANs Enabled: ALL
-# Pruning VLANs Enabled: 2-1001
-# Capture Mode Disabled
-# Capture VLANs Allowed: ALL
-#
-# Name: Gi0/2
-# Switchport: Enabled
-# Administrative Mode: dynamic auto
-# Operational Mode: static access
-# Administrative Trunking Encapsulation: negotiate
-# Operational Trunking Encapsulation: native
-# Negotiation of Trunking: Off
-# Access Mode VLAN: 1 (default)
-# Trunking Native Mode VLAN: 1 (default)
-# Administrative Native VLAN tagging: enabled
-# Voice VLAN: none
-# Administrative private-vlan host-association: none 
-# Administrative private-vlan mapping: none 
-# Administrative private-vlan trunk native VLAN: none
-# Administrative private-vlan trunk Native VLAN tagging: enabled
-# Administrative private-vlan trunk encapsulation: dot1q
-# Administrative private-vlan trunk normal VLANs: none
-# Administrative private-vlan trunk associations: none
-# Administrative private-vlan trunk mappings: none
-# Operational private-vlan: none
-# Trunking VLANs Enabled: ALL
-# Pruning VLANs Enabled: 2-1001
-# Capture Mode Disabled
-# Capture VLANs Allowed: ALL#
+# viosl2#show running-config | section ^interface
+# interface GigabitEthernet0/1
+#  description Configured by Ansible
+#  negotiation auto
+# interface GigabitEthernet0/2
+#  description This is test
+#  media-type rj45
+#  negotiation auto

--- a/ios/l2_interfaces/ios_l2_interface.yaml
+++ b/ios/l2_interfaces/ios_l2_interface.yaml
@@ -41,10 +41,10 @@ DOCUMENTATION: |
           - Switchport mode trunk command to configure the interface as a Layer 2 trunk.
             Note The encapsulation is always set to dot1q.
           suboptions:
-            vlans:
+            allowed_vlans:
               description:
-              - List of VLANs to be configured in trunk port. It's used as the VLAN range to ADD
-                or REMOVE from the trunk.
+              - List of allowed VLANs in a given trunk port. These are the only VLANs that will be
+                configured on the trunk.
               type: list
             native_vlan:
               description:
@@ -55,15 +55,10 @@ DOCUMENTATION: |
               - Trunking encapsulation when interface is in trunking mode.
               choices: ['dot1q','isl', 'negotiate']
               type: str
-            pruning_vlan:
+            pruning_vlans:
               description:
               - Pruning VLAN to be configured in trunk port. It's used as the trunk pruning VLAN ID.
-              type: str
-            trunk_allowed_vlans:
-              description:
-              - List of allowed VLANs in a given trunk port. These are the only VLANs that will be
-                configured on the trunk, i.e. "2-10,15".
-              type: str
+              type: list
     state:
       choices:
       - merged

--- a/ios/l2_interfaces/ios_l2_interface.yaml
+++ b/ios/l2_interfaces/ios_l2_interface.yaml
@@ -50,6 +50,15 @@ DOCUMENTATION: |
               description:
               - Native VLAN to be configured in trunk port. It's used as the trunk native VLAN ID.
               type: str
+            encapsulation:
+              description:
+              - Trunking encapsulation when interface is in trunking mode.
+              choices: ['dot1q','isl', 'negotiate']
+              type: str
+            pruning_vlan:
+              description:
+              - Pruning VLAN to be configured in trunk port. It's used as the trunk pruning VLAN ID.
+              type: str
             trunk_allowed_vlans:
               description:
               - List of allowed VLANs in a given trunk port. These are the only VLANs that will be

--- a/ios/l2_interfaces/ios_l2_interface.yaml
+++ b/ios/l2_interfaces/ios_l2_interface.yaml
@@ -59,6 +59,25 @@ DOCUMENTATION: |
               description:
               - Pruning VLAN to be configured in trunk port. It's used as the trunk pruning VLAN ID.
               type: list
+        encapsulation:
+          description:
+          - Configuring IP routing on a LAN subinterface is only allowed if that subinterface is
+            already configured as part of an IEEE 802.10, IEEE 802.1Q, or ISL vLAN. Note, that this
+            parameter should only be used with Sub-Interface.
+          suboptions:
+            dot1q:
+              description:
+              - IEEE 802.1Q Virtual LAN ID, valid vlan range is between 1-4094.
+              type: str
+            isl:
+              description:
+              - Inter Switch Link - Virtual LAN encapsulation, valid vlan identifier range is
+                between 1-1000.
+              type: str
+            priority_tag:
+              description:
+              - Priority-tagged (VLAN 0).
+              type: str
     state:
       choices:
       - merged

--- a/ios/l2_interfaces/ios_l2_interface.yaml
+++ b/ios/l2_interfaces/ios_l2_interface.yaml
@@ -25,38 +25,36 @@ DOCUMENTATION: |
       suboptions:
         name:
           description:
-          - Full name of interface, e.g. ge-0/0/0.
+          - Full name of the interface excluding any logical unit number, i.e. GigabitEthernet0/1.
           type: str
           required: True
-        mode:
-          default: access
+        access:
           description:
-          - Mode in which interface needs to be configured
-          type: str
-          choices: ['access', 'trunk']
-        access_vlan:
+          - Switchport mode access command to configure the interface as a layer 2 access.
+          suboptions:
+            vlan:
+              description:
+              - Configure given VLAN in access port. It's used as the access VLAN ID.
+            type: str
+        trunk:
           description:
-          - Configure given VLAN in access port. If C(mode=access), used as the access VLAN ID.
-        type: str
-        trunk_vlans:
-          description:
-          - List of VLANs to be configured in trunk port. If C(mode=trunk), used as the VLAN
-            range to ADD or REMOVE from the trunk.
-          type: str
-        native_vlan:
-          description:
-          - Native VLAN to be configured in trunk port. If C(mode=trunk), used as the trunk
-            native VLAN ID.
-          type: str
-        trunk_allowed_vlans:
-          description:
-          - List of allowed VLANs in a given trunk port. If C(mode=trunk), these are the only
-            VLANs that will be configured on the trunk, i.e. "2-10,15".
-          type: str
-        aggregate:
-          description:
-          - List of Layer-2 interface definitions.
-          type: str
+          - Switchport mode trunk command to configure the interface as a Layer 2 trunk.
+            Note The encapsulation is always set to dot1q.
+          suboptions:
+            vlans:
+              description:
+              - List of VLANs to be configured in trunk port. It's used as the VLAN range to ADD
+                or REMOVE from the trunk.
+              type: list
+            native_vlan:
+              description:
+              - Native VLAN to be configured in trunk port. It's used as the trunk native VLAN ID.
+              type: str
+            trunk_allowed_vlans:
+              description:
+              - List of allowed VLANs in a given trunk port. These are the only VLANs that will be
+                configured on the trunk, i.e. "2-10,15".
+              type: str
     state:
       choices:
       - merged

--- a/ios/l2_interfaces/ios_l2_interface.yaml
+++ b/ios/l2_interfaces/ios_l2_interface.yaml
@@ -1,0 +1,74 @@
+---
+GENERATOR_VERSION: '1.0'
+
+ANSIBLE_METADATA: |
+    {
+      'metadata_version': '1.1',
+      'status': ['preview'],
+      'supported_by': 'network'
+    }
+NETWORK_OS: ios
+RESOURCE: l2_interfaces
+COPYRIGHT: Copyright 2019 Red Hat
+
+DOCUMENTATION: |
+  module: ios_l2_interfaces
+  version_added: 2.9
+  short_description: Manage Layer-2 interface on Cisco IOS devices.
+  description: This module provides declarative management of Layer-2 interface on Cisco IOS devices.
+  author: Sumit Jaiswal (@justjais)
+  options:
+    config:
+      description: A dictionary of Layer-2 interface options
+      type: list
+      elements: dict
+      suboptions:
+        name:
+          description:
+          - Full name of interface, e.g. ge-0/0/0.
+          type: str
+          required: True
+        mode:
+          default: access
+          description:
+          - Mode in which interface needs to be configured
+          type: str
+          choices: ['access', 'trunk']
+        access_vlan:
+          description:
+          - Configure given VLAN in access port. If C(mode=access), used as the access VLAN ID.
+        type: str
+        trunk_vlans:
+          description:
+          - List of VLANs to be configured in trunk port. If C(mode=trunk), used as the VLAN
+            range to ADD or REMOVE from the trunk.
+          type: str
+        native_vlan:
+          description:
+          - Native VLAN to be configured in trunk port. If C(mode=trunk), used as the trunk
+            native VLAN ID.
+          type: str
+        trunk_allowed_vlans:
+          description:
+          - List of allowed VLANs in a given trunk port. If C(mode=trunk), these are the only
+            VLANs that will be configured on the trunk, i.e. "2-10,15".
+          type: str
+        aggregate:
+          description:
+          - List of Layer-2 interface definitions.
+          type: str
+    state:
+      choices:
+      - merged
+      - replaced
+      - overridden
+      - deleted
+      default: merged
+      description:
+      - The state the configuration should be left in
+      type: str
+EXAMPLES:
+  - deleted_example_01.txt
+  - merged_example_01.txt
+  - overridden_example_01.txt
+  - replaced_example_01.txt

--- a/ios/l2_interfaces/merged_example_01.txt
+++ b/ios/l2_interfaces/merged_example_01.txt
@@ -1,0 +1,120 @@
+# Using merged
+
+# Before state:
+# -------------
+#
+# viosl2#show interfaces switchport
+# Name: Gi0/1
+# Switchport: Enabled
+# Administrative Mode: static access
+# Operational Mode: static access
+# Administrative Trunking Encapsulation: negotiate
+# Operational Trunking Encapsulation: native
+# Negotiation of Trunking: Off
+# Access Mode VLAN: 1 (default)
+# Trunking Native Mode VLAN: 1 (default)
+# Administrative Native VLAN tagging: enabled
+# Voice VLAN: none
+# Administrative private-vlan host-association: none 
+# Administrative private-vlan mapping: none 
+# Administrative private-vlan trunk native VLAN: none
+# Administrative private-vlan trunk Native VLAN tagging: enabled
+# Administrative private-vlan trunk encapsulation: dot1q
+# Administrative private-vlan trunk normal VLANs: none
+# Administrative private-vlan trunk associations: none
+# Administrative private-vlan trunk mappings: none
+# Operational private-vlan: none
+# Trunking VLANs Enabled: ALL
+# Pruning VLANs Enabled: 2-1001
+# Capture Mode Disabled
+# Capture VLANs Allowed: ALL
+#
+# Name: Gi0/2
+# Switchport: Enabled
+# Administrative Mode: static access
+# Operational Mode: static access
+# Administrative Trunking Encapsulation: dot1q
+# Operational Trunking Encapsulation: native
+# Negotiation of Trunking: Off
+# Access Mode VLAN: 10 (VLAN0010)
+# Trunking Native Mode VLAN: 1 (default)
+# Administrative Native VLAN tagging: enabled
+# Voice VLAN: none
+# Administrative private-vlan host-association: none 
+# Administrative private-vlan mapping: none 
+# Administrative private-vlan trunk native VLAN: none
+# Administrative private-vlan trunk Native VLAN tagging: enabled
+# Administrative private-vlan trunk encapsulation: dot1q
+# Administrative private-vlan trunk normal VLANs: none
+# Administrative private-vlan trunk associations: none
+# Administrative private-vlan trunk mappings: none
+# Operational private-vlan: none
+# Trunking VLANs Enabled: ALL
+# Pruning VLANs Enabled: 2-1001
+# Capture Mode Disabled
+# Capture VLANs Allowed: ALL
+
+- name: Merge provided configuration with device configuration
+  ios_interfaces:
+    config:
+      - name: GigabitEthernet0/1
+        mode: access
+        access_vlan: 20
+      - name: GigabitEthernet0/2
+        mode: trunk
+        native_vlan: 20
+    operation: merged
+
+# After state:
+# ------------
+#
+# viosl2#show interfaces switchport
+# Name: Gi0/1
+# Switchport: Enabled
+# Administrative Mode: static access
+# Operational Mode: static access
+# Administrative Trunking Encapsulation: negotiate
+# Operational Trunking Encapsulation: native
+# Negotiation of Trunking: Off
+# Access Mode VLAN: 20 (VLAN0020)
+# Trunking Native Mode VLAN: 1 (default)
+# Administrative Native VLAN tagging: enabled
+# Voice VLAN: none
+# Administrative private-vlan host-association: none
+# Administrative private-vlan mapping: none
+# Administrative private-vlan trunk native VLAN: none
+# Administrative private-vlan trunk Native VLAN tagging: enabled
+# Administrative private-vlan trunk encapsulation: dot1q
+# Administrative private-vlan trunk normal VLANs: none
+# Administrative private-vlan trunk associations: none
+# Administrative private-vlan trunk mappings: none
+# Operational private-vlan: none
+# Trunking VLANs Enabled: ALL
+# Pruning VLANs Enabled: 2-1001
+# Capture Mode Disabled
+# Capture VLANs Allowed: ALL
+#
+# Name: Gi0/2
+# Switchport: Enabled
+# Administrative Mode: trunk
+# Operational Mode: trunk
+# Administrative Trunking Encapsulation: dot1q
+# Operational Trunking Encapsulation: dot1q
+# Negotiation of Trunking: On
+# Access Mode VLAN: 10 (VLAN0010)
+# Trunking Native Mode VLAN: 20 (VLAN0020)
+# Administrative Native VLAN tagging: enabled
+# Voice VLAN: none
+# Administrative private-vlan host-association: none
+# Administrative private-vlan mapping: none
+# Administrative private-vlan trunk native VLAN: none
+# Administrative private-vlan trunk Native VLAN tagging: enabled
+# Administrative private-vlan trunk encapsulation: dot1q
+# Administrative private-vlan trunk normal VLANs: none
+# Administrative private-vlan trunk associations: none
+# Administrative private-vlan trunk mappings: none
+# Operational private-vlan: none
+# Trunking VLANs Enabled: ALL
+# Pruning VLANs Enabled: 2-1001
+# Capture Mode Disabled
+# Capture VLANs Allowed: ALL

--- a/ios/l2_interfaces/merged_example_01.txt
+++ b/ios/l2_interfaces/merged_example_01.txt
@@ -22,11 +22,12 @@
         - vlan: 10
       - name: GigabitEthernet0/2
         trunk:
-        - vlans:
+        - allowed_vlans:
           - 20
           - 40
           native_vlan: 20
-          pruning_vlan: 10
+          pruning_vlans:
+          - 10
           encapsulation: dot1q
     state: merged
 

--- a/ios/l2_interfaces/merged_example_01.txt
+++ b/ios/l2_interfaces/merged_example_01.txt
@@ -18,11 +18,11 @@
   ios_interfaces:
     config:
       - name: GigabitEthernet0/1
-        mode: access
-        access_vlan: 10
+        access:
+        - vlan: 10
       - name: GigabitEthernet0/2
-        mode: trunk
-        native_vlan: 20
+        trunk:
+        - native_vlan: 20
     operation: merged
 
 # After state:

--- a/ios/l2_interfaces/merged_example_01.txt
+++ b/ios/l2_interfaces/merged_example_01.txt
@@ -22,8 +22,13 @@
         - vlan: 10
       - name: GigabitEthernet0/2
         trunk:
-        - native_vlan: 20
-    operation: merged
+        - vlans:
+          - 20
+          - 40
+          native_vlan: 20
+          pruning_vlan: 10
+          encapsulation: dot1q
+    state: merged
 
 # After state:
 # ------------
@@ -36,8 +41,10 @@
 #  negotiation auto
 # interface GigabitEthernet0/2
 #  description This is test
+#  switchport trunk allowed vlan 20,40
 #  switchport trunk encapsulation dot1q
 #  switchport trunk native vlan 20
+#  switchport trunk pruning vlan 10
 #  switchport mode trunk
 #  media-type rj45
 #  negotiation auto

--- a/ios/l2_interfaces/merged_example_01.txt
+++ b/ios/l2_interfaces/merged_example_01.txt
@@ -29,6 +29,9 @@
           pruning_vlans:
           - 10
           encapsulation: dot1q
+      - name: GigabitEthernet0/3.100
+        encapsulation:
+        - dot1q: 20
     state: merged
 
 # After state:
@@ -49,3 +52,5 @@
 #  switchport mode trunk
 #  media-type rj45
 #  negotiation auto
+# interface GigabitEthernet0/3.100
+#  encapsulation dot1Q 20

--- a/ios/l2_interfaces/merged_example_01.txt
+++ b/ios/l2_interfaces/merged_example_01.txt
@@ -3,63 +3,23 @@
 # Before state:
 # -------------
 #
-# viosl2#show interfaces switchport
-# Name: Gi0/1
-# Switchport: Enabled
-# Administrative Mode: static access
-# Operational Mode: static access
-# Administrative Trunking Encapsulation: negotiate
-# Operational Trunking Encapsulation: native
-# Negotiation of Trunking: Off
-# Access Mode VLAN: 1 (default)
-# Trunking Native Mode VLAN: 1 (default)
-# Administrative Native VLAN tagging: enabled
-# Voice VLAN: none
-# Administrative private-vlan host-association: none 
-# Administrative private-vlan mapping: none 
-# Administrative private-vlan trunk native VLAN: none
-# Administrative private-vlan trunk Native VLAN tagging: enabled
-# Administrative private-vlan trunk encapsulation: dot1q
-# Administrative private-vlan trunk normal VLANs: none
-# Administrative private-vlan trunk associations: none
-# Administrative private-vlan trunk mappings: none
-# Operational private-vlan: none
-# Trunking VLANs Enabled: ALL
-# Pruning VLANs Enabled: 2-1001
-# Capture Mode Disabled
-# Capture VLANs Allowed: ALL
-#
-# Name: Gi0/2
-# Switchport: Enabled
-# Administrative Mode: static access
-# Operational Mode: static access
-# Administrative Trunking Encapsulation: dot1q
-# Operational Trunking Encapsulation: native
-# Negotiation of Trunking: Off
-# Access Mode VLAN: 10 (VLAN0010)
-# Trunking Native Mode VLAN: 1 (default)
-# Administrative Native VLAN tagging: enabled
-# Voice VLAN: none
-# Administrative private-vlan host-association: none 
-# Administrative private-vlan mapping: none 
-# Administrative private-vlan trunk native VLAN: none
-# Administrative private-vlan trunk Native VLAN tagging: enabled
-# Administrative private-vlan trunk encapsulation: dot1q
-# Administrative private-vlan trunk normal VLANs: none
-# Administrative private-vlan trunk associations: none
-# Administrative private-vlan trunk mappings: none
-# Operational private-vlan: none
-# Trunking VLANs Enabled: ALL
-# Pruning VLANs Enabled: 2-1001
-# Capture Mode Disabled
-# Capture VLANs Allowed: ALL
+# viosl2#show running-config | section ^interface
+# interface GigabitEthernet0/1
+#  description Configured by Ansible
+#  negotiation auto
+# interface GigabitEthernet0/2
+#  description This is test
+#  switchport access vlan 20
+#  switchport mode access
+#  media-type rj45
+#  negotiation auto
 
 - name: Merge provided configuration with device configuration
   ios_interfaces:
     config:
       - name: GigabitEthernet0/1
         mode: access
-        access_vlan: 20
+        access_vlan: 10
       - name: GigabitEthernet0/2
         mode: trunk
         native_vlan: 20
@@ -68,53 +28,16 @@
 # After state:
 # ------------
 #
-# viosl2#show interfaces switchport
-# Name: Gi0/1
-# Switchport: Enabled
-# Administrative Mode: static access
-# Operational Mode: static access
-# Administrative Trunking Encapsulation: negotiate
-# Operational Trunking Encapsulation: native
-# Negotiation of Trunking: Off
-# Access Mode VLAN: 20 (VLAN0020)
-# Trunking Native Mode VLAN: 1 (default)
-# Administrative Native VLAN tagging: enabled
-# Voice VLAN: none
-# Administrative private-vlan host-association: none
-# Administrative private-vlan mapping: none
-# Administrative private-vlan trunk native VLAN: none
-# Administrative private-vlan trunk Native VLAN tagging: enabled
-# Administrative private-vlan trunk encapsulation: dot1q
-# Administrative private-vlan trunk normal VLANs: none
-# Administrative private-vlan trunk associations: none
-# Administrative private-vlan trunk mappings: none
-# Operational private-vlan: none
-# Trunking VLANs Enabled: ALL
-# Pruning VLANs Enabled: 2-1001
-# Capture Mode Disabled
-# Capture VLANs Allowed: ALL
-#
-# Name: Gi0/2
-# Switchport: Enabled
-# Administrative Mode: trunk
-# Operational Mode: trunk
-# Administrative Trunking Encapsulation: dot1q
-# Operational Trunking Encapsulation: dot1q
-# Negotiation of Trunking: On
-# Access Mode VLAN: 10 (VLAN0010)
-# Trunking Native Mode VLAN: 20 (VLAN0020)
-# Administrative Native VLAN tagging: enabled
-# Voice VLAN: none
-# Administrative private-vlan host-association: none
-# Administrative private-vlan mapping: none
-# Administrative private-vlan trunk native VLAN: none
-# Administrative private-vlan trunk Native VLAN tagging: enabled
-# Administrative private-vlan trunk encapsulation: dot1q
-# Administrative private-vlan trunk normal VLANs: none
-# Administrative private-vlan trunk associations: none
-# Administrative private-vlan trunk mappings: none
-# Operational private-vlan: none
-# Trunking VLANs Enabled: ALL
-# Pruning VLANs Enabled: 2-1001
-# Capture Mode Disabled
-# Capture VLANs Allowed: ALL
+# viosl2#show running-config | section ^interface
+# interface GigabitEthernet0/1
+#  description Configured by Ansible
+#  switchport access vlan 10
+#  switchport mode access
+#  negotiation auto
+# interface GigabitEthernet0/2
+#  description This is test
+#  switchport trunk encapsulation dot1q
+#  switchport trunk native vlan 20
+#  switchport mode trunk
+#  media-type rj45
+#  negotiation auto

--- a/ios/l2_interfaces/override_example_01.txt
+++ b/ios/l2_interfaces/override_example_01.txt
@@ -1,0 +1,117 @@
+# Using overridden
+
+# Before state:
+# -------------
+#
+# viosl2#show interfaces switchport
+# Name: Gi0/1
+# Switchport: Enabled
+# Administrative Mode: static access
+# Operational Mode: static access
+# Administrative Trunking Encapsulation: negotiate
+# Operational Trunking Encapsulation: native
+# Negotiation of Trunking: Off
+# Access Mode VLAN: 1 (default)
+# Trunking Native Mode VLAN: 1 (default)
+# Administrative Native VLAN tagging: enabled
+# Voice VLAN: none
+# Administrative private-vlan host-association: none 
+# Administrative private-vlan mapping: none 
+# Administrative private-vlan trunk native VLAN: none
+# Administrative private-vlan trunk Native VLAN tagging: enabled
+# Administrative private-vlan trunk encapsulation: dot1q
+# Administrative private-vlan trunk normal VLANs: none
+# Administrative private-vlan trunk associations: none
+# Administrative private-vlan trunk mappings: none
+# Operational private-vlan: none
+# Trunking VLANs Enabled: ALL
+# Pruning VLANs Enabled: 2-1001
+# Capture Mode Disabled
+# Capture VLANs Allowed: ALL
+#
+# Name: Gi0/2
+# Switchport: Enabled
+# Administrative Mode: static access
+# Operational Mode: static access
+# Administrative Trunking Encapsulation: dot1q
+# Operational Trunking Encapsulation: native
+# Negotiation of Trunking: Off
+# Access Mode VLAN: 10 (VLAN0010)
+# Trunking Native Mode VLAN: 1 (default)
+# Administrative Native VLAN tagging: enabled
+# Voice VLAN: none
+# Administrative private-vlan host-association: none 
+# Administrative private-vlan mapping: none 
+# Administrative private-vlan trunk native VLAN: none
+# Administrative private-vlan trunk Native VLAN tagging: enabled
+# Administrative private-vlan trunk encapsulation: dot1q
+# Administrative private-vlan trunk normal VLANs: none
+# Administrative private-vlan trunk associations: none
+# Administrative private-vlan trunk mappings: none
+# Operational private-vlan: none
+# Trunking VLANs Enabled: ALL
+# Pruning VLANs Enabled: 2-1001
+# Capture Mode Disabled
+# Capture VLANs Allowed: ALL
+
+- name: Override device configuration of all l2 interfaces with provided configuration
+  ios_interfaces:
+    config:
+      - name: GigabitEthernet0/2
+        mode: access
+        access_vlan: 20
+    operation: overridden
+
+# After state:
+# -------------
+#
+# viosl2#show interfaces switchport
+# Name: Gi0/1
+# Switchport: Enabled
+# Administrative Mode: static access
+# Operational Mode: static access
+# Administrative Trunking Encapsulation: negotiate
+# Operational Trunking Encapsulation: native
+# Negotiation of Trunking: Off
+# Access Mode VLAN: 1 (default)
+# Trunking Native Mode VLAN: 1 (default)
+# Administrative Native VLAN tagging: enabled
+# Voice VLAN: none
+# Administrative private-vlan host-association: none 
+# Administrative private-vlan mapping: none 
+# Administrative private-vlan trunk native VLAN: none
+# Administrative private-vlan trunk Native VLAN tagging: enabled
+# Administrative private-vlan trunk encapsulation: dot1q
+# Administrative private-vlan trunk normal VLANs: none
+# Administrative private-vlan trunk associations: none
+# Administrative private-vlan trunk mappings: none
+# Operational private-vlan: none
+# Trunking VLANs Enabled: ALL
+# Pruning VLANs Enabled: 2-1001
+# Capture Mode Disabled
+# Capture VLANs Allowed: ALL
+#
+# Name: Gi0/2
+# Switchport: Enabled
+# Administrative Mode: static access
+# Operational Mode: static access
+# Administrative Trunking Encapsulation: dot1q
+# Operational Trunking Encapsulation: native
+# Negotiation of Trunking: Off
+# Access Mode VLAN: 20 (VLAN0020)
+# Trunking Native Mode VLAN: 1 (default)
+# Administrative Native VLAN tagging: enabled
+# Voice VLAN: none
+# Administrative private-vlan host-association: none
+# Administrative private-vlan mapping: none
+# Administrative private-vlan trunk native VLAN: none
+# Administrative private-vlan trunk Native VLAN tagging: enabled
+# Administrative private-vlan trunk encapsulation: dot1q
+# Administrative private-vlan trunk normal VLANs: none
+# Administrative private-vlan trunk associations: none
+# Administrative private-vlan trunk mappings: none
+# Operational private-vlan: none
+# Trunking VLANs Enabled: ALL
+# Pruning VLANs Enabled: 2-1001
+# Capture Mode Disabled
+# Capture VLANs Allowed: ALL

--- a/ios/l2_interfaces/override_example_01.txt
+++ b/ios/l2_interfaces/override_example_01.txt
@@ -3,56 +3,21 @@
 # Before state:
 # -------------
 #
-# viosl2#show interfaces switchport
-# Name: Gi0/1
-# Switchport: Enabled
-# Administrative Mode: static access
-# Operational Mode: static access
-# Administrative Trunking Encapsulation: negotiate
-# Operational Trunking Encapsulation: native
-# Negotiation of Trunking: Off
-# Access Mode VLAN: 1 (default)
-# Trunking Native Mode VLAN: 1 (default)
-# Administrative Native VLAN tagging: enabled
-# Voice VLAN: none
-# Administrative private-vlan host-association: none 
-# Administrative private-vlan mapping: none 
-# Administrative private-vlan trunk native VLAN: none
-# Administrative private-vlan trunk Native VLAN tagging: enabled
-# Administrative private-vlan trunk encapsulation: dot1q
-# Administrative private-vlan trunk normal VLANs: none
-# Administrative private-vlan trunk associations: none
-# Administrative private-vlan trunk mappings: none
-# Operational private-vlan: none
-# Trunking VLANs Enabled: ALL
-# Pruning VLANs Enabled: 2-1001
-# Capture Mode Disabled
-# Capture VLANs Allowed: ALL
-#
-# Name: Gi0/2
-# Switchport: Enabled
-# Administrative Mode: static access
-# Operational Mode: static access
-# Administrative Trunking Encapsulation: dot1q
-# Operational Trunking Encapsulation: native
-# Negotiation of Trunking: Off
-# Access Mode VLAN: 10 (VLAN0010)
-# Trunking Native Mode VLAN: 1 (default)
-# Administrative Native VLAN tagging: enabled
-# Voice VLAN: none
-# Administrative private-vlan host-association: none 
-# Administrative private-vlan mapping: none 
-# Administrative private-vlan trunk native VLAN: none
-# Administrative private-vlan trunk Native VLAN tagging: enabled
-# Administrative private-vlan trunk encapsulation: dot1q
-# Administrative private-vlan trunk normal VLANs: none
-# Administrative private-vlan trunk associations: none
-# Administrative private-vlan trunk mappings: none
-# Operational private-vlan: none
-# Trunking VLANs Enabled: ALL
-# Pruning VLANs Enabled: 2-1001
-# Capture Mode Disabled
-# Capture VLANs Allowed: ALL
+# viosl2#show running-config | section ^interface
+# interface GigabitEthernet0/1
+#  description Configured by Ansible
+#  switchport trunk encapsulation dot1q
+#  switchport trunk native vlan 20
+#  switchport mode trunk
+#  negotiation auto
+# interface GigabitEthernet0/2
+#  description This is test
+#  switchport access vlan 20
+#  switchport trunk encapsulation dot1q
+#  switchport trunk native vlan 20
+#  switchport mode trunk
+#  media-type rj45
+#  negotiation auto
 
 - name: Override device configuration of all l2 interfaces with provided configuration
   ios_interfaces:
@@ -65,53 +30,13 @@
 # After state:
 # -------------
 #
-# viosl2#show interfaces switchport
-# Name: Gi0/1
-# Switchport: Enabled
-# Administrative Mode: static access
-# Operational Mode: static access
-# Administrative Trunking Encapsulation: negotiate
-# Operational Trunking Encapsulation: native
-# Negotiation of Trunking: Off
-# Access Mode VLAN: 1 (default)
-# Trunking Native Mode VLAN: 1 (default)
-# Administrative Native VLAN tagging: enabled
-# Voice VLAN: none
-# Administrative private-vlan host-association: none 
-# Administrative private-vlan mapping: none 
-# Administrative private-vlan trunk native VLAN: none
-# Administrative private-vlan trunk Native VLAN tagging: enabled
-# Administrative private-vlan trunk encapsulation: dot1q
-# Administrative private-vlan trunk normal VLANs: none
-# Administrative private-vlan trunk associations: none
-# Administrative private-vlan trunk mappings: none
-# Operational private-vlan: none
-# Trunking VLANs Enabled: ALL
-# Pruning VLANs Enabled: 2-1001
-# Capture Mode Disabled
-# Capture VLANs Allowed: ALL
-#
-# Name: Gi0/2
-# Switchport: Enabled
-# Administrative Mode: static access
-# Operational Mode: static access
-# Administrative Trunking Encapsulation: dot1q
-# Operational Trunking Encapsulation: native
-# Negotiation of Trunking: Off
-# Access Mode VLAN: 20 (VLAN0020)
-# Trunking Native Mode VLAN: 1 (default)
-# Administrative Native VLAN tagging: enabled
-# Voice VLAN: none
-# Administrative private-vlan host-association: none
-# Administrative private-vlan mapping: none
-# Administrative private-vlan trunk native VLAN: none
-# Administrative private-vlan trunk Native VLAN tagging: enabled
-# Administrative private-vlan trunk encapsulation: dot1q
-# Administrative private-vlan trunk normal VLANs: none
-# Administrative private-vlan trunk associations: none
-# Administrative private-vlan trunk mappings: none
-# Operational private-vlan: none
-# Trunking VLANs Enabled: ALL
-# Pruning VLANs Enabled: 2-1001
-# Capture Mode Disabled
-# Capture VLANs Allowed: ALL
+# viosl2#show running-config | section ^interface
+# interface GigabitEthernet0/1
+#  description Configured by Ansible
+#  negotiation auto
+# interface GigabitEthernet0/2
+#  description This is test
+#  switchport access vlan 20
+#  switchport mode access
+#  media-type rj45
+#  negotiation auto

--- a/ios/l2_interfaces/override_example_01.txt
+++ b/ios/l2_interfaces/override_example_01.txt
@@ -25,7 +25,7 @@
       - name: GigabitEthernet0/2
         access:
         - vlan: 20
-    operation: overridden
+    state: overridden
 
 # After state:
 # -------------

--- a/ios/l2_interfaces/override_example_01.txt
+++ b/ios/l2_interfaces/override_example_01.txt
@@ -18,6 +18,8 @@
 #  switchport mode trunk
 #  media-type rj45
 #  negotiation auto
+# interface GigabitEthernet0/3.100
+#  encapsulation dot1Q 20
 
 - name: Override device configuration of all l2 interfaces with provided configuration
   ios_interfaces:
@@ -40,3 +42,5 @@
 #  switchport mode access
 #  media-type rj45
 #  negotiation auto
+# interface GigabitEthernet0/3.100
+

--- a/ios/l2_interfaces/override_example_01.txt
+++ b/ios/l2_interfaces/override_example_01.txt
@@ -23,8 +23,8 @@
   ios_interfaces:
     config:
       - name: GigabitEthernet0/2
-        mode: access
-        access_vlan: 20
+        access:
+        - vlan: 20
     operation: overridden
 
 # After state:

--- a/ios/l2_interfaces/replaced_example_01.txt
+++ b/ios/l2_interfaces/replaced_example_01.txt
@@ -15,6 +15,8 @@
 #  switchport mode access
 #  media-type rj45
 #  negotiation auto
+# interface GigabitEthernet0/3.100
+#  encapsulation dot1Q 20
 
 - name: Replaces device configuration of listed l2 interfaces with provided configuration
   ios_interfaces:
@@ -28,7 +30,10 @@
           trunk_vlans: 5-10
           pruning_vlans:
           - 10
-          encapsulation: isl
+          encapsulation: dot1q
+      - name: GigabitEthernet0/3.100
+        encapsulation:
+        - isl: 10
     state: replaced
 
 # After state:
@@ -43,9 +48,11 @@
 # interface GigabitEthernet0/2
 #  description This is test
 #  switchport trunk allowed vlan 20,40
-#  switchport trunk encapsulation isl
+#  switchport trunk encapsulation dot1q
 #  switchport trunk native vlan 20
 #  switchport trunk pruning vlan 10
 #  switchport mode trunk
 #  media-type rj45
 #  negotiation auto
+# interface GigabitEthernet0/3.100
+#  encapsulation isl 10

--- a/ios/l2_interfaces/replaced_example_01.txt
+++ b/ios/l2_interfaces/replaced_example_01.txt
@@ -3,56 +3,18 @@
 # Before state:
 # -------------
 #
-# viosl2#show interfaces switchport
-# Name: Gi0/1
-# Switchport: Enabled
-# Administrative Mode: static access
-# Operational Mode: static access
-# Administrative Trunking Encapsulation: negotiate
-# Operational Trunking Encapsulation: native
-# Negotiation of Trunking: Off
-# Access Mode VLAN: 1 (default)
-# Trunking Native Mode VLAN: 1 (default)
-# Administrative Native VLAN tagging: enabled
-# Voice VLAN: none
-# Administrative private-vlan host-association: none 
-# Administrative private-vlan mapping: none 
-# Administrative private-vlan trunk native VLAN: none
-# Administrative private-vlan trunk Native VLAN tagging: enabled
-# Administrative private-vlan trunk encapsulation: dot1q
-# Administrative private-vlan trunk normal VLANs: none
-# Administrative private-vlan trunk associations: none
-# Administrative private-vlan trunk mappings: none
-# Operational private-vlan: none
-# Trunking VLANs Enabled: ALL
-# Pruning VLANs Enabled: 2-1001
-# Capture Mode Disabled
-# Capture VLANs Allowed: ALL
-#
-# Name: Gi0/2
-# Switchport: Enabled
-# Administrative Mode: static access
-# Operational Mode: static access
-# Administrative Trunking Encapsulation: dot1q
-# Operational Trunking Encapsulation: native
-# Negotiation of Trunking: Off
-# Access Mode VLAN: 10 (VLAN0010)
-# Trunking Native Mode VLAN: 1 (default)
-# Administrative Native VLAN tagging: enabled
-# Voice VLAN: none
-# Administrative private-vlan host-association: none 
-# Administrative private-vlan mapping: none 
-# Administrative private-vlan trunk native VLAN: none
-# Administrative private-vlan trunk Native VLAN tagging: enabled
-# Administrative private-vlan trunk encapsulation: dot1q
-# Administrative private-vlan trunk normal VLANs: none
-# Administrative private-vlan trunk associations: none
-# Administrative private-vlan trunk mappings: none
-# Operational private-vlan: none
-# Trunking VLANs Enabled: ALL
-# Pruning VLANs Enabled: 2-1001
-# Capture Mode Disabled
-# Capture VLANs Allowed: ALL
+# viosl2#show running-config | section ^interface
+# interface GigabitEthernet0/1
+#  description Configured by Ansible
+#  switchport access vlan 20
+#  switchport mode access
+#  negotiation auto
+# interface GigabitEthernet0/2
+#  description This is test
+#  switchport access vlan 20
+#  switchport mode access
+#  media-type rj45
+#  negotiation auto
 
 - name: Replaces device configuration of listed l2 interfaces with provided configuration
   ios_interfaces:
@@ -66,53 +28,16 @@
 # After state:
 # -------------
 #
-# viosl2#show interfaces switchport
-# Name: Gi0/1
-# Switchport: Enabled
-# Administrative Mode: static access
-# Operational Mode: static access
-# Administrative Trunking Encapsulation: negotiate
-# Operational Trunking Encapsulation: native
-# Negotiation of Trunking: Off
-# Access Mode VLAN: 1 (default)
-# Trunking Native Mode VLAN: 1 (default)
-# Administrative Native VLAN tagging: enabled
-# Voice VLAN: none
-# Administrative private-vlan host-association: none
-# Administrative private-vlan mapping: none
-# Administrative private-vlan trunk native VLAN: none
-# Administrative private-vlan trunk Native VLAN tagging: enabled
-# Administrative private-vlan trunk encapsulation: dot1q
-# Administrative private-vlan trunk normal VLANs: none
-# Administrative private-vlan trunk associations: none
-# Administrative private-vlan trunk mappings: none
-# Operational private-vlan: none
-# Trunking VLANs Enabled: ALL
-# Pruning VLANs Enabled: 2-1001
-# Capture Mode Disabled
-# Capture VLANs Allowed: ALL
-#
-# Name: Gi0/2
-# Switchport: Enabled
-# Administrative Mode: trunk
-# Operational Mode: trunk
-# Administrative Trunking Encapsulation: dot1q
-# Operational Trunking Encapsulation: dot1q
-# Negotiation of Trunking: On
-# Access Mode VLAN: 10 (VLAN0010)
-# Trunking Native Mode VLAN: 20 (VLAN0020)
-# Administrative Native VLAN tagging: enabled
-# Voice VLAN: none
-# Administrative private-vlan host-association: none
-# Administrative private-vlan mapping: none
-# Administrative private-vlan trunk native VLAN: none
-# Administrative private-vlan trunk Native VLAN tagging: enabled
-# Administrative private-vlan trunk encapsulation: dot1q
-# Administrative private-vlan trunk normal VLANs: none
-# Administrative private-vlan trunk associations: none
-# Administrative private-vlan trunk mappings: none
-# Operational private-vlan: none
-# Trunking VLANs Enabled: ALL
-# Pruning VLANs Enabled: 2-1001
-# Capture Mode Disabled
-# Capture VLANs Allowed: ALL
+# viosl2#show running-config | section ^interface
+# interface GigabitEthernet0/1
+#  description Configured by Ansible
+#  switchport access vlan 20
+#  switchport mode access
+#  negotiation auto
+# interface GigabitEthernet0/2
+#  description This is test
+#  switchport trunk encapsulation dot1q
+#  switchport trunk native vlan 20
+#  switchport mode trunk
+#  media-type rj45
+#  negotiation auto

--- a/ios/l2_interfaces/replaced_example_01.txt
+++ b/ios/l2_interfaces/replaced_example_01.txt
@@ -20,9 +20,9 @@
   ios_interfaces:
     config:
       - name: GigabitEthernet0/2
-        mode: trunk
-	native_vlan: 20
-        trunk_vlans: 5-10
+        trunk:
+	- native_vlan: 20
+          trunk_vlans: 5-10
     operation: replaced
 
 # After state:

--- a/ios/l2_interfaces/replaced_example_01.txt
+++ b/ios/l2_interfaces/replaced_example_01.txt
@@ -21,9 +21,14 @@
     config:
       - name: GigabitEthernet0/2
         trunk:
-	- native_vlan: 20
+	- vlans:
+          - 20
+          - 40
+          native_vlan: 20
           trunk_vlans: 5-10
-    operation: replaced
+          pruning_vlan: 10
+          encapsulation: isl
+    state: replaced
 
 # After state:
 # -------------
@@ -36,8 +41,10 @@
 #  negotiation auto
 # interface GigabitEthernet0/2
 #  description This is test
-#  switchport trunk encapsulation dot1q
+#  switchport trunk allowed vlan 20,40
+#  switchport trunk encapsulation isl
 #  switchport trunk native vlan 20
+#  switchport trunk pruning vlan 10
 #  switchport mode trunk
 #  media-type rj45
 #  negotiation auto

--- a/ios/l2_interfaces/replaced_example_01.txt
+++ b/ios/l2_interfaces/replaced_example_01.txt
@@ -1,0 +1,121 @@
+# Using replaced
+
+# Before state:
+# -------------
+#
+# Before state:
+# -------------
+#
+# viosl2#show interfaces switchport
+# Name: Gi0/1
+# Switchport: Enabled
+# Administrative Mode: static access
+# Operational Mode: static access
+# Administrative Trunking Encapsulation: negotiate
+# Operational Trunking Encapsulation: native
+# Negotiation of Trunking: Off
+# Access Mode VLAN: 1 (default)
+# Trunking Native Mode VLAN: 1 (default)
+# Administrative Native VLAN tagging: enabled
+# Voice VLAN: none
+# Administrative private-vlan host-association: none 
+# Administrative private-vlan mapping: none 
+# Administrative private-vlan trunk native VLAN: none
+# Administrative private-vlan trunk Native VLAN tagging: enabled
+# Administrative private-vlan trunk encapsulation: dot1q
+# Administrative private-vlan trunk normal VLANs: none
+# Administrative private-vlan trunk associations: none
+# Administrative private-vlan trunk mappings: none
+# Operational private-vlan: none
+# Trunking VLANs Enabled: ALL
+# Pruning VLANs Enabled: 2-1001
+# Capture Mode Disabled
+# Capture VLANs Allowed: ALL
+#
+# Name: Gi0/2
+# Switchport: Enabled
+# Administrative Mode: static access
+# Operational Mode: static access
+# Administrative Trunking Encapsulation: dot1q
+# Operational Trunking Encapsulation: native
+# Negotiation of Trunking: Off
+# Access Mode VLAN: 10 (VLAN0010)
+# Trunking Native Mode VLAN: 1 (default)
+# Administrative Native VLAN tagging: enabled
+# Voice VLAN: none
+# Administrative private-vlan host-association: none 
+# Administrative private-vlan mapping: none 
+# Administrative private-vlan trunk native VLAN: none
+# Administrative private-vlan trunk Native VLAN tagging: enabled
+# Administrative private-vlan trunk encapsulation: dot1q
+# Administrative private-vlan trunk normal VLANs: none
+# Administrative private-vlan trunk associations: none
+# Administrative private-vlan trunk mappings: none
+# Operational private-vlan: none
+# Trunking VLANs Enabled: ALL
+# Pruning VLANs Enabled: 2-1001
+# Capture Mode Disabled
+# Capture VLANs Allowed: ALL
+
+- name: Replaces device configuration of listed l2 interfaces with provided configuration
+  ios_interfaces:
+    config:
+      - name: GigabitEthernet0/2
+        mode: trunk
+	native_vlan: 20
+        trunk_vlans: 5-10
+    operation: replaced
+
+# After state:
+# -------------
+#
+# viosl2#show interfaces switchport
+# Name: Gi0/1
+# Switchport: Enabled
+# Administrative Mode: static access
+# Operational Mode: static access
+# Administrative Trunking Encapsulation: negotiate
+# Operational Trunking Encapsulation: native
+# Negotiation of Trunking: Off
+# Access Mode VLAN: 1 (default)
+# Trunking Native Mode VLAN: 1 (default)
+# Administrative Native VLAN tagging: enabled
+# Voice VLAN: none
+# Administrative private-vlan host-association: none
+# Administrative private-vlan mapping: none
+# Administrative private-vlan trunk native VLAN: none
+# Administrative private-vlan trunk Native VLAN tagging: enabled
+# Administrative private-vlan trunk encapsulation: dot1q
+# Administrative private-vlan trunk normal VLANs: none
+# Administrative private-vlan trunk associations: none
+# Administrative private-vlan trunk mappings: none
+# Operational private-vlan: none
+# Trunking VLANs Enabled: ALL
+# Pruning VLANs Enabled: 2-1001
+# Capture Mode Disabled
+# Capture VLANs Allowed: ALL
+#
+# Name: Gi0/2
+# Switchport: Enabled
+# Administrative Mode: trunk
+# Operational Mode: trunk
+# Administrative Trunking Encapsulation: dot1q
+# Operational Trunking Encapsulation: dot1q
+# Negotiation of Trunking: On
+# Access Mode VLAN: 10 (VLAN0010)
+# Trunking Native Mode VLAN: 20 (VLAN0020)
+# Administrative Native VLAN tagging: enabled
+# Voice VLAN: none
+# Administrative private-vlan host-association: none
+# Administrative private-vlan mapping: none
+# Administrative private-vlan trunk native VLAN: none
+# Administrative private-vlan trunk Native VLAN tagging: enabled
+# Administrative private-vlan trunk encapsulation: dot1q
+# Administrative private-vlan trunk normal VLANs: none
+# Administrative private-vlan trunk associations: none
+# Administrative private-vlan trunk mappings: none
+# Operational private-vlan: none
+# Trunking VLANs Enabled: ALL
+# Pruning VLANs Enabled: 2-1001
+# Capture Mode Disabled
+# Capture VLANs Allowed: ALL

--- a/ios/l2_interfaces/replaced_example_01.txt
+++ b/ios/l2_interfaces/replaced_example_01.txt
@@ -3,9 +3,6 @@
 # Before state:
 # -------------
 #
-# Before state:
-# -------------
-#
 # viosl2#show interfaces switchport
 # Name: Gi0/1
 # Switchport: Enabled

--- a/ios/l2_interfaces/replaced_example_01.txt
+++ b/ios/l2_interfaces/replaced_example_01.txt
@@ -21,12 +21,13 @@
     config:
       - name: GigabitEthernet0/2
         trunk:
-	- vlans:
+	- allowed_vlans:
           - 20
           - 40
           native_vlan: 20
           trunk_vlans: 5-10
-          pruning_vlan: 10
+          pruning_vlans:
+          - 10
           encapsulation: isl
     state: replaced
 


### PR DESCRIPTION
Adding ios_l2_interfaces model in the new format which is similar to the Ansible module documentation format.