### PR TITLE
Add nxos_ospfv3 model docstring

### DIFF
--- a/models/nxos/ospfv3/ospfv3.yaml
+++ b/models/nxos/ospfv3/ospfv3.yaml
@@ -1,0 +1,772 @@
+module: nxos_ospfv3
+short_description: OSPFv3 resource module
+description:
+- This module manages OSPFv3 configuration on devices running Cisco NX-OS.
+version_added: 1.1.0
+notes:
+- Tested against NX-OS 7.0(3)I5(1).
+- This module works with connection C(network_cli) and C(httpapi).
+author: Nilashish Chakraborty (@NilashishC)
+options:
+  running_config:
+    description:
+    - This option is used only with state I(parsed).
+    - The value of this option should be the output received from the NX-OS device
+      by executing the command B(show running-config | section "^router ospf .*").
+    - The state I(parsed) reads the configuration from C(running_config) option and
+      transforms it into Ansible structured data as per the resource module's argspec
+      and the value is then returned in the I(parsed) key within the result.
+    type: str
+  config:
+    description: A list of OSPFv3 process configuration.
+    type: dict
+    suboptions:
+      processes:
+        description:
+        - A list of OSPFv3 instances' configurations.
+        type: list
+        elements: dict
+        suboptions:
+          address_family:
+            description:
+            - IPv6 unicast address-family OSPFv3 settings.
+            type: dict
+            suboptions:
+              afi:
+                description:
+                - Configure OSPFv3 settings under IPv6 address-family.
+                type: str
+                choices: ['ipv6']
+              safi:
+                description:
+                - Configure OSPFv3 settings under IPv6 unicast address-family.
+                type: str
+                choices: ['unicast']
+              areas:
+                description:
+                - Configure properties of OSPF Areas under address-family.
+                type: list
+                elements: dict
+                suboptions:
+                  area_id:
+                    description:
+                    - The Area ID as an integer or IP Address.
+                    type: str
+                    required: True
+                  default_cost:
+                    description:
+                    - Specify the default cost.
+                    type: int
+                  filter_list:
+                    description:
+                    - Filter prefixes between OSPF areas.
+                    type: list
+                    elements: dict
+                    suboptions:
+                      route_map:
+                        description:
+                        - The Route-map name.
+                        type: str
+                        required: True
+                      direction:
+                        description:
+                        - The direction to apply the route map.
+                        type: str
+                        choices: [in, out]
+                        required: True
+                  ranges:
+                    description:
+                    - Configure an address range for the area.
+                    type: list
+                    elements: dict
+                    suboptions:
+                      prefix:
+                        description:
+                        - IP in Prefix format (x.x.x.x/len)
+                        type: str
+                        required: True
+                      cost:
+                        description:
+                        - Cost to use for the range.
+                        type: int
+                      not_advertise:
+                        description:
+                        - Suppress advertising the specified range.
+                        type: bool
+              default_information:
+                description:
+                - Control distribution of default routes.
+                type: dict
+                suboptions:
+                  originate:
+                    description:
+                    - Distribute a default route.
+                    type: dict
+                    suboptions:
+                      set:
+                        description:
+                        - Enable distribution of default route.
+                        type: bool
+                      always:
+                        description:
+                        - Always advertise a default route.
+                        type: bool
+                      route_map:
+                        description:
+                        - Policy to control distribution of default routes
+                        type: str
+              distance:
+                description:
+                - Configure the OSPF administrative distance.
+                type: int
+              maximum_paths:
+                description:
+                - Maximum paths per destination.
+                type: int
+              redistribute:
+                description:
+                - Redistribute information from another routing protocol.
+                type: list
+                elements: dict
+                suboptions:
+                  protocol:
+                    description:
+                    - The name of the protocol.
+                    type: str
+                    choices: [bgp, direct, eigrp, isis, lisp, ospfv3, rip, static]
+                    required: True
+                  id:
+                    description:
+                    - The identifier for the protocol specified.
+                    type: str
+                  route_map:
+                    description:
+                    - The route map policy to constrain redistribution.
+                    type: str
+                    required: True
+              summary_address:
+                description:
+                - Configure route summarization for redistribution.
+                type: list
+                elements: dict
+                suboptions:
+                  prefix:
+                    description:
+                    - IPv6 prefix format 'xxxx:xxxx/ml', 'xxxx:xxxx::/ml' or 'xxxx::xx/128'
+                    type: str
+                    required: True
+                  not_advertise:
+                    description:
+                    - Supress advertising the specified summary.
+                    type: bool
+                  tag:
+                    description:
+                    - A 32-bit tag value.
+                    type: int
+              table_map:
+                description:
+                - Policy for filtering/modifying OSPF routes before sending them to
+                  RIB.
+                type: dict
+                suboptions:
+                  name:
+                    description:
+                    - The Route Map name.
+                    type: str
+                    required: True
+                  filter:
+                    description:
+                    - Block the OSPF routes from being sent to RIB.
+                    type: bool
+              timers:
+                description:
+                - Configure timer related constants.
+                type: dict
+                suboptions:
+                  throttle:
+                    description:
+                    - Configure throttle related constants.
+                    type: dict
+                    suboptions:
+                      spf:
+                        description:
+                        - Set OSPF SPF timers.
+                        type: dict
+                        suboptions:
+                          initial_spf_delay:
+                            description:
+                            - Initial SPF schedule delay in milliseconds.
+                            type: int
+                          min_hold_time:
+                            description:
+                            - Minimum hold time between SPF calculations.
+                            type: int
+                          max_wait_time:
+                            description:
+                            - Maximum wait time between SPF calculations.
+                            type: int
+          areas:
+            description:
+            - Configure properties of OSPF Areas.
+            type: list
+            elements: dict
+            suboptions:
+              area_id:
+                description:
+                - The Area ID as an integer or IP Address.
+                type: str
+                required: True
+              nssa:
+                description:
+                - NSSA settings for the area.
+                type: dict
+                suboptions:
+                  set:
+                    description:
+                    - Configure area as NSSA.
+                    type: bool
+                  default_information_originate:
+                    description:
+                    - Originate Type-7 default LSA into NSSA area.
+                    type: bool
+                  no_redistribution:
+                    description:
+                    - Do not send redistributed LSAs into NSSA area.
+                    type: bool
+                  no_summary:
+                    description:
+                    - Do not send summary LSAs into NSSA area.
+                    type: bool
+                  translate:
+                    description:
+                    - Translate LSA.
+                    type: dict
+                    suboptions:
+                      type7:
+                        description:
+                        - Translate from Type 7 to Type 5.
+                        type: dict
+                        suboptions:
+                          always:
+                            description:
+                            - Always translate LSAs
+                            type: bool
+                          never:
+                            description:
+                            - Never translate LSAs
+                            type: bool
+                          supress_fa:
+                            description:
+                            - Suppress forwarding address in translated LSAs.
+                            type: bool
+              stub:
+                description:
+                - Settings for configuring the area as a stub.
+                type: dict
+                suboptions:
+                  set:
+                    description:
+                    - Configure the area as a stub.
+                    type: bool
+                  no_summary:
+                    description:
+                    - Prevent ABR from sending summary LSAs into stub area.
+                    type: bool
+          auto_cost:
+            description:
+            - Calculate OSPF cost according to bandwidth.
+            type: dict
+            suboptions:
+              reference_bandwidth:
+                description:
+                - Reference bandwidth used to assign OSPF cost.
+                type: int
+                required: True
+              unit:
+                description:
+                - Specify in which unit the reference bandwidth is specified.
+                type: str
+                required: True
+                choices: [Gbps, Mbps]
+          flush_routes:
+            description:
+            - Flush routes on a non-graceful controlled restart.
+            type: bool
+          graceful_restart:
+            description:
+            - Configure graceful restart.
+            type: dict
+            suboptions:
+              set:
+                description:
+                - Enable graceful-restart.
+                type: bool
+              grace_period:
+                description:
+                - Configure maximum interval to restart gracefully.
+                type: int
+              helper_disable:
+                description:
+                - Enable/Disable helper mode.
+                type: bool
+              planned_only:
+                description:
+                - Enable graceful restart only for a planned restart
+                type: bool
+          isolate:
+            description:
+            - Isolate this router from OSPF perspective.
+            type: bool
+          log_adjacency_changes:
+            description:
+            - Log changes in adjacency state.
+            type: dict
+            suboptions:
+              log:
+                description:
+                - Enable/disable logging changes in adjacency state.
+                type: bool
+              detail:
+                description:
+                - Notify all state changes.
+                type: bool
+          max_lsa:
+            description:
+            - Feature to limit the number of non-self-originated LSAs.
+            type: dict
+            suboptions:
+              max_non_self_generated_lsa:
+                description:
+                - Set the maximum number of non self-generated LSAs.
+                type: int
+                required: True
+              threshold:
+                description:
+                - Threshold value (%) at which to generate a warning message.
+                type: int
+              ignore_count:
+                description:
+                - Set count on how many times adjacencies can be suppressed.
+                type: int
+              ignore_time:
+                description:
+                - Set time during which all adjacencies are suppressed.
+                type: int
+              reset_time:
+                description:
+                - Set number of minutes after which ignore-count is reset to zero.
+                type: int
+              warning_only:
+                description:
+                - Log a warning message when limit is exceeded.
+                type: bool
+          max_metric:
+            description:
+            - Maximize the cost metric.
+            type: dict
+            suboptions:
+              router_lsa:
+                description:
+                - Router LSA configuration.
+                type: dict
+                suboptions:
+                  set:
+                    description:
+                    - Set router-lsa attribute.
+                    type: bool
+                  external_lsa:
+                    description:
+                    - External LSA configuration.
+                    type: dict
+                    suboptions:
+                      set:
+                        description:
+                        - Set external-lsa attribute.
+                        type: bool
+                      max_metric_value:
+                        description:
+                        - Set max metric value for external LSAs.
+                        type: int
+                  stub_prefix_lsa:
+                    description:
+                    - Advertise Max metric for Stub links as well.
+                    type: bool
+                  on_startup:
+                    description:
+                    - Effective only at startup.
+                    type: dict
+                    suboptions:
+                      set:
+                        description:
+                        - Set on-startup attribute.
+                        type: bool
+                      wait_period:
+                        description:
+                        - Wait period in seconds after startup.
+                        type: int
+                      wait_for_bgp_asn:
+                        description:
+                        - ASN of BGP to wait for.
+                        type: int
+                  inter_area_prefix_lsa:
+                    description:
+                    - Inter-area-prefix LSAs configuration.
+                    type: dict
+                    suboptions:
+                      set:
+                        description:
+                        - Set summary-lsa attribute.
+                        type: bool
+                      max_metric_value:
+                        description:
+                        - Max metric value for summary LSAs.
+                        type: int
+          name_lookup:
+            description:
+            - Display OSPF router ids as DNS names.
+            type: bool
+          passive_interface:
+            description:
+            - Suppress routing updates on the interface.
+            type: dict
+            suboptions:
+              default:
+                description:
+                - Interfaces passive by default.
+                type: bool
+          process_id:
+            description:
+            - The OSPF process tag.
+            type: str
+            required: True
+          router_id:
+            description:
+            - Set OSPF process router-id.
+            type: str
+          shutdown:
+            description:
+            - Shutdown the OSPF protocol instance.
+            type: bool
+          timers:
+            description:
+            - Configure timer related constants.
+            type: dict
+            suboptions:
+              lsa_arrival:
+                description:
+                - Mimimum interval between arrival of a LSA.
+                type: int
+              lsa_group_pacing:
+                description:
+                - LSA group refresh/maxage interval.
+                type: int
+              throttle:
+                description:
+                - Configure throttle related constants.
+                type: dict
+                suboptions:
+                  lsa:
+                    description:
+                    - Set rate-limiting for LSA generation.
+                    type: dict
+                    suboptions:
+                      start_interval:
+                        description:
+                        - The start interval.
+                        type: int
+                      hold_interval:
+                        description:
+                        - The hold interval.
+                        type: int
+                      max_interval:
+                        description:
+                        - The max interval.
+                        type: int
+          vrfs:
+            description:
+            - Configure VRF specific OSPF settings.
+            type: list
+            elements: dict
+            suboptions:
+              areas:
+                description:
+                - Configure properties of OSPF Areas.
+                type: list
+                elements: dict
+                suboptions:
+                  area_id:
+                    description:
+                    - The Area ID as an integer or IP Address.
+                    type: str
+                    required: True
+                  nssa:
+                    description:
+                    - NSSA settings for the area.
+                    type: dict
+                    suboptions:
+                      set:
+                        description:
+                        - Configure area as NSSA.
+                        type: bool
+                      default_information_originate:
+                        description:
+                        - Originate Type-7 default LSA into NSSA area.
+                        type: bool
+                      no_redistribution:
+                        description:
+                        - Do not send redistributed LSAs into NSSA area.
+                        type: bool
+                      no_summary:
+                        description:
+                        - Do not send summary LSAs into NSSA area.
+                        type: bool
+                      translate:
+                        description:
+                        - Translate LSA.
+                        type: dict
+                        suboptions:
+                          type7:
+                            description:
+                            - Translate from Type 7 to Type 5.
+                            type: dict
+                            suboptions:
+                              always:
+                                description:
+                                - Always translate LSAs
+                                type: bool
+                              never:
+                                description:
+                                - Never translate LSAs
+                                type: bool
+                              supress_fa:
+                                description:
+                                - Suppress forwarding address in translated LSAs.
+                                type: bool
+                  stub:
+                    description:
+                    - Settings for configuring the area as a stub.
+                    type: dict
+                    suboptions:
+                      set:
+                        description:
+                        - Configure the area as a stub.
+                        type: bool
+                      no_summary:
+                        description:
+                        - Prevent ABR from sending summary LSAs into stub area.
+                        type: bool
+              auto_cost:
+                description:
+                - Calculate OSPF cost according to bandwidth.
+                type: dict
+                suboptions:
+                  reference_bandwidth:
+                    description:
+                    - Reference bandwidth used to assign OSPF cost.
+                    type: int
+                    required: True
+                  unit:
+                    description:
+                    - Specify in which unit the reference bandwidth is specified.
+                    type: str
+                    required: True
+                    choices: [Gbps, Mbps]
+              graceful_restart:
+                description:
+                - Configure graceful restart.
+                type: dict
+                suboptions:
+                  set:
+                    description:
+                    - Enable graceful-restart.
+                    type: bool
+                  grace_period:
+                    description:
+                    - Configure maximum interval to restart gracefully.
+                    type: int
+                  helper_disable:
+                    description:
+                    - Enable/Disable helper mode.
+                    type: bool
+                  planned_only:
+                    description:
+                    - Enable graceful restart only for a planned restart
+                    type: bool
+              log_adjacency_changes:
+                description:
+                - Log changes in adjacency state.
+                type: dict
+                suboptions:
+                  log:
+                    description:
+                    - Enable/disable logging changes in adjacency state.
+                    type: bool
+                  detail:
+                    description:
+                    - Notify all state changes.
+                    type: bool
+              max_lsa:
+                description:
+                - Feature to limit the number of non-self-originated LSAs.
+                type: dict
+                suboptions:
+                  max_non_self_generated_lsa:
+                    description:
+                    - Set the maximum number of non self-generated LSAs.
+                    type: int
+                    required: True
+                  threshold:
+                    description:
+                    - Threshold value (%) at which to generate a warning message.
+                    type: int
+                  ignore_count:
+                    description:
+                    - Set count on how many times adjacencies can be suppressed.
+                    type: int
+                  ignore_time:
+                    description:
+                    - Set time during which all adjacencies are suppressed.
+                    type: int
+                  reset_time:
+                    description:
+                    - Set number of minutes after which ignore-count is reset to zero.
+                    type: int
+                  warning_only:
+                    description:
+                    - Log a warning message when limit is exceeded.
+                    type: bool
+              max_metric:
+                description:
+                - Maximize the cost metric.
+                type: dict
+                suboptions:
+                  router_lsa:
+                    description:
+                    - Router LSA configuration.
+                    type: dict
+                    suboptions:
+                      set:
+                        description:
+                        - Set router-lsa attribute.
+                        type: bool
+                      external_lsa:
+                        description:
+                        - External LSA configuration.
+                        type: dict
+                        suboptions:
+                          set:
+                            description:
+                            - Set external-lsa attribute.
+                            type: bool
+                          max_metric_value:
+                            description:
+                            - Set max metric value for external LSAs.
+                            type: int
+                      stub_prefix_lsa:
+                        description:
+                        - Advertise Max metric for Stub links as well.
+                        type: bool
+                      on_startup:
+                        description:
+                        - Effective only at startup.
+                        type: dict
+                        suboptions:
+                          set:
+                            description:
+                            - Set on-startup attribute.
+                            type: bool
+                          wait_period:
+                            description:
+                            - Wait period in seconds after startup.
+                            type: int
+                          wait_for_bgp_asn:
+                            description:
+                            - ASN of BGP to wait for.
+                            type: int
+                      inter_area_prefix_lsa:
+                        description:
+                        - Inter-area-prefix LSAs configuration.
+                        type: dict
+                        suboptions:
+                          set:
+                            description:
+                            - Set summary-lsa attribute.
+                            type: bool
+                          max_metric_value:
+                            description:
+                            - Max metric value for summary LSAs.
+                            type: int
+              name_lookup:
+                description:
+                - Display OSPF router ids as DNS names.
+                type: bool
+              passive_interface:
+                description:
+                - Suppress routing updates on the interface.
+                type: dict
+                suboptions:
+                  default:
+                    description:
+                    - Interfaces passive by default.
+                    type: bool
+              router_id:
+                description:
+                - Set OSPF process router-id.
+                type: str
+              shutdown:
+                description:
+                - Shutdown the OSPF protocol instance.
+                type: bool
+              timers:
+                description:
+                - Configure timer related constants.
+                type: dict
+                suboptions:
+                  lsa_arrival:
+                    description:
+                    - Mimimum interval between arrival of a LSA.
+                    type: int
+                  lsa_group_pacing:
+                    description:
+                    - LSA group refresh/maxage interval.
+                    type: int
+                  throttle:
+                    description:
+                    - Configure throttle related constants.
+                    type: dict
+                    suboptions:
+                      lsa:
+                        description:
+                        - Set rate-limiting for LSA generation.
+                        type: dict
+                        suboptions:
+                          start_interval:
+                            description:
+                            - The start interval.
+                            type: int
+                          hold_interval:
+                            description:
+                            - The hold interval.
+                            type: int
+                          max_interval:
+                            description:
+                            - The max interval.
+                            type: int
+              vrf:
+                description:
+                - Name/Identifier of the VRF.
+                type: str
+                required: True
+  state:
+    description:
+    - The state the configuration should be left in.
+    type: str
+    choices:
+    - merged
+    - replaced
+    - overridden
+    - deleted
+    - gathered
+    - parsed
+    - rendered
+    default: merged

--- a/models/nxos/ospfv3/ospfv3.yaml
+++ b/models/nxos/ospfv3/ospfv3.yaml
@@ -2,7 +2,7 @@ module: nxos_ospfv3
 short_description: OSPFv3 resource module
 description:
 - This module manages OSPFv3 configuration on devices running Cisco NX-OS.
-version_added: 1.1.0
+version_added: 1.2.0
 notes:
 - Tested against NX-OS 7.0(3)I5(1).
 - This module works with connection C(network_cli) and C(httpapi).
@@ -12,7 +12,7 @@ options:
     description:
     - This option is used only with state I(parsed).
     - The value of this option should be the output received from the NX-OS device
-      by executing the command B(show running-config | section "^router ospf .*").
+      by executing the command B(show running-config | section '^router ospfv3').
     - The state I(parsed) reads the configuration from C(running_config) option and
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result.


### PR DESCRIPTION
- Targets https://github.com/ansible-collections/cisco.nxos/issues/104
- Adds model docstring for nxos_ospfv3 (to be run with [cli_rm_builder](https://github.com/ansible-network/cli_rm_builder/))