### PR TITLE
Add the ability to log vyos firewall rules.

### DIFF
--- a/models/vyos/firewall_rules/vyos_firewall_rules.yaml
+++ b/models/vyos/firewall_rules/vyos_firewall_rules.yaml
@@ -178,6 +178,11 @@ DOCUMENTATION: |
                           description:
                             - This is the time unit.
                           type: str
+                log:
+                  description:
+                    - Log matching packets.
+                  type: str
+                  choices: ['disable', 'enable']
                 p2p:
                   description:
                     - P2P application packets.


### PR DESCRIPTION
I have added to the vyos_firewall_rules.yaml, and am unsure whether I need to add anything to the example .txt files as well? Please let me know if so.

Uses the same syntax as native vyos. The parameter is called 'log' and can take the values 'disable' or 'enable'. This parameter is optional. If left out logging is not done.
