### PR TITLE
Updated examples to accommodate bgp neighbors attribute additions

### DIFF
--- a/models/enterprise_sonic/bgp_neighbors/deleted_example_03.txt
+++ b/models/enterprise_sonic/bgp_neighbors/deleted_example_03.txt
@@ -70,25 +70,6 @@
      - bgp_as: 51
        neighbors:
          - neighbor: Eth1/2
-           auth_pwd:
-             pwd: 'pw123'
-             encrypted: false
-           dont_negotiate_capability: true
-           ebgp_multihop:
-             enabled: true
-             multihop_ttl: 1
-           enforce_first_as: true
-           enforce_multihop: true
-           local_address: 'Ethernet4'
-           local_as:
-             as: 2
-             no_prepend: true
-             replace_as: true
-           nbr_description: "description 1"
-           override_capability: true
-           passive: true
-           port: 3
-           solo: true
          - neighbor: 1.1.1.1
            disable_connected_check: true
            ttl_security: 5
@@ -125,11 +106,7 @@
              holdtime: 15
            bfd: true
            capability:
-             dynamic: true
-             extended_nexthop: true
            auth_pwd:
-               pwd: 'U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg='
-               encrypted: true
            nbr_description: 'description 2'
            strict_capability_match: true
            v6only: true
@@ -147,5 +124,4 @@
 # !
 # neighbor interface Eth1/3
 # !
-# neighbor interface Eth1/2
 # neighbor 1.1.1.1

--- a/models/enterprise_sonic/bgp_neighbors/deleted_example_03.txt
+++ b/models/enterprise_sonic/bgp_neighbors/deleted_example_03.txt
@@ -104,7 +104,7 @@
            timers:
              keepalive: 30
              holdtime: 15
-           bfd: true
+           bfd:
            capability:
            auth_pwd:
            nbr_description: 'description 2'

--- a/models/enterprise_sonic/bgp_neighbors/deleted_example_03.txt
+++ b/models/enterprise_sonic/bgp_neighbors/deleted_example_03.txt
@@ -3,50 +3,137 @@
 # Before state:
 # -------------
 #
+#router bgp 11 vrf VrfCheck2
+# network import-check
+# timers 60 180
+#!
 #router bgp 51 vrf VrfReg1
 # network import-check
 # timers 60 180
 # !
 # peer-group SPINE
-#  bfd
 #  remote-as 4
+#  bfd
+#  capability dynamic
+#  capability extended-nexthop
+#  address-family ipv4 unicast
+#   activate
+#   allowas-in origin
+#   send-community both
+# !
+#  address-family ipv6 unicast
+#   activate
+#   allowas-in 5
+#   send-community both
 # !
 # neighbor interface Eth1/3
+#  description "description 2"
 #  peer-group SPINE
 #  remote-as 10
 #  timers 15 30
 #  advertisement-interval 15
-#  bfd 
+#  bfd
 #  capability extended-nexthop
 #  capability dynamic
+#  v6only
+#  password U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg= encrypted
+#  strict-capability-match
 # !
 # neighbor 192.168.1.4
-# !
+#!
+# router bgp 51
+#  timers 60 180
+# neighbor interface Eth1/2
+#  description "description 1"
+#  ebgp-multihop 1
+#  remote-as external
+#  update-source interface Ethernet4
+#  dont-capability-negotiate
+#  enforce-first-as
+#  enforce-multihop
+#  local-as 2 no-prepend replace-as
+#  override-capability
+#  passive
+#  password U2FsdGVkX1+bxMf9TKOhaXRNNaHmywiEVDF2lJ2c000= encrypted
+#  port 3
+#  solo
+# neighbor 1.1.1.1
+#  disable-connected-check
+#  ttl-security hops 5
+#router bgp 11
+# network import-check
+# timers 60 180
 
 - name: "Delete specific sonic_bgp_neighbors"
   sonic_bgp_neighbors:
     config:
-      - bgp_as: 51
-        vrf_name: VrfReg1
-        peer_group:
-          - name: SPINE
-            bfd: true
-            remote_as:
-              peer_as: 4
-        neighbors:
-          - neighbor: Eth1/3
-            remote_as:
-              peer_as: 10
-            peer_group: SPINE
-            advertisement_interval: 15
-            timers:
-              keepalive: 30
-              holdtime: 15
-            bfd: true
-            capability:
-              dynamic: true
-              extended_nexthop: true
-          - neighbor: 192.168.1.4
+     - bgp_as: 51
+       neighbors:
+         - neighbor: Eth1/2
+           auth_pwd:
+             pwd: 'pw123'
+             encrypted: false
+           dont_negotiate_capability: true
+           ebgp_multihop:
+             enabled: true
+             multihop_ttl: 1
+           enforce_first_as: true
+           enforce_multihop: true
+           local_address: 'Ethernet4'
+           local_as:
+             as: 2
+             no_prepend: true
+             replace_as: true
+           nbr_description: "description 1"
+           override_capability: true
+           passive: true
+           port: 3
+           solo: true
+         - neighbor: 1.1.1.1
+           disable_connected_check: true
+           ttl_security: 5
+     - bgp_as: 51
+       vrf_name: VrfReg1
+       peer_group:
+         - name: SPINE
+           bfd: true
+           capability:
+             dynamic: true
+             extended_nexthop: true
+           remote_as:
+             peer_as: 4
+           address_family:
+             afis:
+               - afi: ipv4
+                 safi: unicast
+                 activate: true
+                 allowas_in:
+                   origin: true
+               - afi: ipv6
+                 safi: unicast
+                 activate: true
+                 allowas_in:
+                   value: 5
+       neighbors:
+         - neighbor: Eth1/3
+           remote_as:
+             peer_as: 10
+           peer_group: SPINE
+           advertisement_interval: 15
+           timers:
+             keepalive: 30
+             holdtime: 15
+           bfd: true
+           capability:
+             dynamic: true
+             extended_nexthop: true
+           auth_pwd:
+               pwd: 'U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg='
+               encrypted: true
+           nbr_description: 'description 2'
+           strict_capability_match: true
+           v6only: true
+         - neighbor: 192.168.1.4
     state: deleted
 
 # After state:
@@ -60,3 +147,5 @@
 # !
 # neighbor interface Eth1/3
 # !
+# neighbor interface Eth1/2
+# neighbor 1.1.1.1

--- a/models/enterprise_sonic/bgp_neighbors/deleted_example_03.txt
+++ b/models/enterprise_sonic/bgp_neighbors/deleted_example_03.txt
@@ -11,11 +11,31 @@
 # network import-check
 # timers 60 180
 # !
+# peer-group SPINE1
+#  timers 15 30
+#  timers connect 25
+#  shutdown message msg1
+#  disable-connected-check
+#  strict-capability-match
+#  ttl-security hops 5
+# !
 # peer-group SPINE
+#  description "description 1"
+#  ebgp-multihop 1
 #  remote-as 4
-#  bfd
+#  bfd check-control-plane-failure profile "profile 1"
+#  update-source interface Ethernet4
 #  capability dynamic
 #  capability extended-nexthop
+#  dont-capability-negotiate
+#  enforce-first-as
+#  enforce-multihop
+#  local-as 2 no-prepend replace-as
+#  override-capability
+#  passive
+#  password U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M= encrypted
+#  solo
+# !
 #  address-family ipv4 unicast
 #   activate
 #   allowas-in origin
@@ -77,24 +97,22 @@
        vrf_name: VrfReg1
        peer_group:
          - name: SPINE
-           bfd: true
+           bfd:
            capability:
-             dynamic: true
-             extended_nexthop: true
+           auth_pwd:
+           dont_negotiate_capability: true
+           ebgp_multihop:
+           enforce_first_as: true
+           enforce_multihop: true
+           local_address: 'Ethernet4'
+           local_as:
+           pg_description: 'description 1'
+           override_capability: true
+           passive: true
+           solo: true
            remote_as:
              peer_as: 4
-           address_family:
-             afis:
-               - afi: ipv4
-                 safi: unicast
-                 activate: true
-                 allowas_in:
-                   origin: true
-               - afi: ipv6
-                 safi: unicast
-                 activate: true
-                 allowas_in:
-                   value: 5
+         - name: SPINE1
        neighbors:
          - neighbor: Eth1/3
            remote_as:

--- a/models/enterprise_sonic/bgp_neighbors/merged_example_01.txt
+++ b/models/enterprise_sonic/bgp_neighbors/merged_example_01.txt
@@ -18,42 +18,73 @@
 - name: "Add sonic_bgp_neighbors"
   sonic_bgp_neighbors:
     config:
-      - bgp_as: 51
-        vrf_name: VrfReg1
-        peer_group:
-          - name: SPINE
-            bfd: true
-            capability:
-              dynamic: true
-              extended_nexthop: true
-            remote_as:
-              peer_as: 4
-            address_family:
-              afis:
-                - afi: ipv4
-                  safi: unicast
-                  activate: true
-                  allowas_in:
-                    origin: true
-                - afi: ipv6
-                  safi: unicast
-                  activate: true
-                  allowas_in:
-                    value: 5
-        neighbors:
-          - neighbor: Eth1/3
-            remote_as:
-              peer_as: 10
-            peer_group: SPINE
-            advertisement_interval: 15
-            timers:
-              keepalive: 30
-              holdtime: 15
-            bfd: true
-            capability:
-              dynamic: true
-              extended_nexthop: true
-          - neighbor: 192.168.1.4
+     - bgp_as: 51
+       neighbors:
+         - neighbor: Eth1/2
+           auth_pwd:
+             pwd: 'pw123'
+             encrypted: false
+           dont_negotiate_capability: true
+           ebgp_multihop:
+             enabled: true
+             multihop_ttl: 1
+           enforce_first_as: true
+           enforce_multihop: true
+           local_address: 'Ethernet4'
+           local_as:
+             as: 2
+             no_prepend: true
+             replace_as: true
+           nbr_description: "description 1"
+           override_capability: true
+           passive: true
+           port: 3
+           solo: true
+         - neighbor: 1.1.1.1
+           disable_connected_check: true
+           ttl_security: 5
+     - bgp_as: 51
+       vrf_name: VrfReg1
+       peer_group:
+         - name: SPINE
+           bfd: true
+           capability:
+             dynamic: true
+             extended_nexthop: true
+           remote_as:
+             peer_as: 4
+           address_family:
+             afis:
+               - afi: ipv4
+                 safi: unicast
+                 activate: true
+                 allowas_in:
+                   origin: true
+               - afi: ipv6
+                 safi: unicast
+                 activate: true
+                 allowas_in:
+                   value: 5
+       neighbors:
+         - neighbor: Eth1/3
+           remote_as:
+             peer_as: 10
+           peer_group: SPINE
+           advertisement_interval: 15
+           timers:
+             keepalive: 30
+             holdtime: 15
+           bfd: true
+           capability:
+             dynamic: true
+             extended_nexthop: true
+           auth_pwd:
+               pwd: 'U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg='
+               encrypted: true
+           nbr_description: 'description 2'
+           strict_capability_match: true
+           v6only: true
+         - neighbor: 192.168.1.4
     state: merged
 
 # After state:
@@ -83,17 +114,39 @@
 #   send-community both
 # !
 # neighbor interface Eth1/3
+#  description "description 2"
 #  peer-group SPINE
 #  remote-as 10
 #  timers 15 30
 #  advertisement-interval 15
-#  bfd 
+#  bfd
 #  capability extended-nexthop
 #  capability dynamic
+#  v6only
+#  password U2FsdGVkX199MZ7YOPkOR9O6wEZmtGSgiDfnlcN9hBg= encrypted
+#  strict-capability-match
 # !
 # neighbor 192.168.1.4
 #!
+# router bgp 51
+#  timers 60 180
+# neighbor interface Eth1/2
+#  description "description 1"
+#  ebgp-multihop 1
+#  remote-as external
+#  update-source interface Ethernet4
+#  dont-capability-negotiate
+#  enforce-first-as
+#  enforce-multihop
+#  local-as 2 no-prepend replace-as
+#  override-capability
+#  passive
+#  password U2FsdGVkX1+bxMf9TKOhaXRNNaHmywiEVDF2lJ2c000= encrypted
+#  port 3
+#  solo
+# neighbor 1.1.1.1
+#  disable-connected-check
+#  ttl-security hops 5
 #router bgp 11
 # network import-check
 # timers 60 180
-#

--- a/models/enterprise_sonic/bgp_neighbors/merged_example_01.txt
+++ b/models/enterprise_sonic/bgp_neighbors/merged_example_01.txt
@@ -48,12 +48,42 @@
        vrf_name: VrfReg1
        peer_group:
          - name: SPINE
-           bfd: true
+           bfd:
+             check_failure: true
+             enabled: true
+             profile: 'profile 1'
            capability:
              dynamic: true
              extended_nexthop: true
+           auth_pwd:
+             pwd: 'U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M='
+             encrypted: true
+           dont_negotiate_capability: true
+           ebgp_multihop:
+             enabled: true
+             multihop_ttl: 1
+           enforce_first_as: true
+           enforce_multihop: true
+           local_address: 'Ethernet4'
+           local_as:
+             as: 2
+             no_prepend: true
+             replace_as: true
+           pg_description: 'description 1'
+           override_capability: true
+           passive: true
+           solo: true
            remote_as:
              peer_as: 4
+         - name: SPINE1
+           disable_connected_check: true
+           shutdown_msg: "msg1"
+           strict_capability_match: true
+           timers:
+             keepalive: 30
+             holdtime: 15
+             connect_retry: 25
+           ttl_security: 5
            address_family:
              afis:
                - afi: ipv4
@@ -103,11 +133,31 @@
 # network import-check
 # timers 60 180
 # !
+# peer-group SPINE1
+#  timers 15 30
+#  timers connect 25
+#  shutdown message msg1
+#  disable-connected-check
+#  strict-capability-match
+#  ttl-security hops 5
+# !
 # peer-group SPINE
+#  description "description 1"
+#  ebgp-multihop 1
 #  remote-as 4
-#  bfd
+#  bfd check-control-plane-failure profile "profile 1"
+#  update-source interface Ethernet4
 #  capability dynamic
 #  capability extended-nexthop
+#  dont-capability-negotiate
+#  enforce-first-as
+#  enforce-multihop
+#  local-as 2 no-prepend replace-as
+#  override-capability
+#  passive
+#  password U2FsdGVkX1/4sRsZ624wbAJfDmagPLq2LsGDOcW/47M= encrypted
+#  solo
+# !
 #  address-family ipv4 unicast
 #   activate
 #   allowas-in origin

--- a/models/enterprise_sonic/bgp_neighbors/merged_example_01.txt
+++ b/models/enterprise_sonic/bgp_neighbors/merged_example_01.txt
@@ -39,6 +39,7 @@
            override_capability: true
            passive: true
            port: 3
+           shutdown_msg: 'msg1'
            solo: true
          - neighbor: 1.1.1.1
            disable_connected_check: true
@@ -74,7 +75,11 @@
            timers:
              keepalive: 30
              holdtime: 15
-           bfd: true
+             connect_retry: 25
+           bfd:
+             check_failure: true
+             enabled: true
+             profile: 'profile 1'
            capability:
              dynamic: true
              extended_nexthop: true
@@ -118,8 +123,9 @@
 #  peer-group SPINE
 #  remote-as 10
 #  timers 15 30
+#  timers connect 25
+#  bfd check-control-plane-failure profile "profile 1"
 #  advertisement-interval 15
-#  bfd
 #  capability extended-nexthop
 #  capability dynamic
 #  v6only
@@ -132,6 +138,7 @@
 #  timers 60 180
 # neighbor interface Eth1/2
 #  description "description 1"
+#  shutdown message msg1
 #  ebgp-multihop 1
 #  remote-as external
 #  update-source interface Ethernet4

--- a/models/enterprise_sonic/bgp_neighbors/sonic_bgp_neighbors.yaml
+++ b/models/enterprise_sonic/bgp_neighbors/sonic_bgp_neighbors.yaml
@@ -98,6 +98,105 @@ DOCUMENTATION: |
                   description:
                     - Enable or disable advertise extended next-hop capability to the peer.
                   type: bool
+            auth_pwd:
+              description:
+                - Configuration for neighbor group authentication password.
+              type: dict
+              suboptions:
+                pwd:
+                  description:
+                    - Authentication password for the neighbor group.
+                  type: str
+                encrypted:
+                  description:
+                    - Indicates whether the password is encrypted text.
+                  type: bool
+                  default: False
+            nbr_description:
+              description:
+                - A textual description of the interface.
+              type: str
+            disable_connected_check:
+              description:
+                - Disables EBGP conntected route check.
+              type: bool
+            dont_negotiate_capability:
+              description:
+                - Disables capability negotiation.
+              type: bool
+            ebgp_multihop:
+              description:
+                - Allow EBGP neighbors not on directly connected networks.
+              type: dict
+              suboptions:
+                enabled:
+                  description:
+                    - Enables the referenced group or neighbors to be indirectly connected.
+                  type: bool
+                  default: False
+                multihop_ttl:
+                  description:
+                    - Time-to-live value to use when packets are sent to the referenced group or neighbors and ebgp-multihop is enabled.
+                  type: int
+            enforce_first_as:
+              description:
+                - Enforces the first AS for EBGP routes.
+              type: bool
+            enforce_multihop:
+              description:
+                - Enforces EBGP multihop performance for neighbor.
+              type: bool
+            local_address:
+              description:
+                - Set the local IP address to use for the session when sending BGP update messages.
+              type: str
+            local_as:
+              description:
+                - Specifies local autonomous system number.
+              type: dict
+              suboptions:
+                as:
+                  description:
+                    - Local autonomous system number.
+                  type: int
+                  required: True
+                no_prepend:
+                  description:
+                    - Do not prepend the local-as number in AS-Path advertisements.
+                  type: bool
+                replace_as:
+                  description:
+                    - Replace the configured AS Number with the local-as number in AS-Path advertisements.
+                  type: bool
+            override_capability:
+              description:
+                - Override capability negotiation result.
+              type: bool
+            passive:
+              description:
+                - Do not send open messages to this neighbor.
+              type: bool
+              default: False
+            port:
+              description:
+                - Neighbor's BGP port.
+              type: int
+            solo:
+              description:
+                - Indicates that routes advertised by the peer should not be reflected back to the peer.
+              type: bool
+            strict_capability_match:
+              description:
+                - Enables strict capability negotiation match.
+              type: bool
+            ttl_security:
+              description:
+                - Enforces only the neighbors that are specified number of hops away will be allowed to become neighbors.
+              type: int
+            v6only:
+              description:
+                - Enables BGP with v6 link-local only.
+              type: bool
             address_family:
               description:
                 - Holds of list of address families associated to the peergroup.

--- a/models/enterprise_sonic/bgp_neighbors/sonic_bgp_neighbors.yaml
+++ b/models/enterprise_sonic/bgp_neighbors/sonic_bgp_neighbors.yaml
@@ -98,6 +98,139 @@ DOCUMENTATION: |
                   description:
                     - Enable or disable advertise extended next-hop capability to the peer.
                   type: bool
+            address_family:
+              description:
+                - Holds of list of address families associated to the peergroup.
+              type: dict
+              suboptions:
+                afis:
+                  description:
+                    - List of address families with afi, safi, activate and allowas-in parameters.
+                    - afi and safi are required together.
+                  type: list
+                  elements: dict
+                  required_together: [['afi', 'safi']]
+                  suboptions:
+                    afi:
+                      description:
+                        - Holds afi mode.
+                      type: str
+                      choices:
+                        - ipv4
+                        - ipv6
+                        - l2vpn
+                    safi:
+                      description:
+                        - Holds safi mode.
+                      type: str
+                      choices:
+                        - unicast
+                        - evpn
+                    activate:
+                      description:
+                        - Enable or disable activate.
+                      type: bool
+                    allowas_in:
+                      description:
+                        - Holds AS value.
+                        - origin and value are mutually exclusive.
+                      type: dict
+                      mutually_exclusive: [['origin', 'value']]
+                      suboptions:
+                        origin:
+                          description:
+                             - Set AS as origin.
+                          type: bool
+                        value:
+                          description:
+                            - Holds AS number in the range 1-10.
+                          type: int
+        neighbors:
+          description:
+            - Specifies BGP neighbor related configurations.
+          type: list
+          elements: dict
+          suboptions:
+            neighbor:
+              description:
+                - Neighbor router address.
+              type: str
+              required: True
+            remote_as:
+              description:
+                - Remote AS of the BGP neighbor to configure.
+              type: dict
+              mutually_exclusive: [['peer_as','peer_type']]
+              suboptions:
+                peer_as:
+                  description:
+                    - Specifies remote AS number.
+                    - The range is from 1 to 4294967295.
+                  type: int
+                peer_type:
+                  description:
+                    - Specifies type of bgp peer.
+                  type: str
+                  choices: ['internal', 'external']
+            bfd:
+              description:
+                - Enables or disables BFD.
+              type: dict
+              suboptions:
+                enabled:
+                  description:
+                    - Enables BFD liveliness check for a BGP neighbor.
+                  type: bool
+                check_failure:
+                  description:
+                    - Link dataplane status with control plane.
+                  type: bool
+                profile:
+                  description:
+                    - BFD Profile name format.
+                  type: str
+            advertisement_interval:
+              description:
+                - Specifies the minimum interval between sending BGP routing updates.
+                - The range is from 0 to 600.
+              type: int
+            peer_group:
+              description:
+                - Name of the peer group that the neighbor is a member of.
+              type: str
+            timers:
+              description:
+                - Specifies BGP neighbor timer related configurations.
+              type: dict
+              suboptions:
+                keepalive:
+                  description:
+                    - Frequency (in seconds) with which the device sends keepalive messages to its peer.
+                    - The range is from 0 to 65535.
+                  type: int
+                holdtime:
+                  description:
+                    - Interval (in seconds) after not receiving a keepalive message that SONiC declares a peer dead.
+                    - The range is from 0 to 65535.
+                  type: int
+                connect_retry:
+                  description:
+                    - Time interval in seconds between attempts to establish a session with the peer.
+                    - The range is from 1 to 65535.
+                  type: int
+            capability:
+              description:
+                - Specifies capability attributes to this neighbor.
+              type: dict
+              suboptions:
+                dynamic:
+                  description:
+                    - Enable or disable dynamic capability to this neighbor.
+                  type: bool
+                extended_nexthop:
+                  description:
+                    - Enable or disable advertise extended next-hop capability to the peer.
+                  type: bool
             auth_pwd:
               description:
                 - Configuration for neighbor group authentication password.
@@ -181,6 +314,10 @@ DOCUMENTATION: |
               description:
                 - Neighbor's BGP port.
               type: int
+            shutdown_msg:
+              description:
+                - Add a shutdown message.
+              type: str
             solo:
               description:
                 - Indicates that routes advertised by the peer should not be reflected back to the peer.
@@ -197,121 +334,6 @@ DOCUMENTATION: |
               description:
                 - Enables BGP with v6 link-local only.
               type: bool
-            address_family:
-              description:
-                - Holds of list of address families associated to the peergroup.
-              type: dict
-              suboptions:
-                afis:
-                  description:
-                    - List of address families with afi, safi, activate and allowas-in parameters.
-                    - afi and safi are required together.
-                  type: list
-                  elements: dict
-                  required_together: [['afi', 'safi']]
-                  suboptions:
-                    afi:
-                      description:
-                        - Holds afi mode.
-                      type: str
-                      choices:
-                        - ipv4
-                        - ipv6
-                        - l2vpn
-                    safi:
-                      description:
-                        - Holds safi mode.
-                      type: str
-                      choices:
-                        - unicast
-                        - evpn
-                    activate:
-                      description:
-                        - Enable or disable activate.
-                      type: bool
-                    allowas_in:
-                      description:
-                        - Holds AS value.
-                        - origin and value are mutually exclusive.
-                      type: dict
-                      mutually_exclusive: [['origin', 'value']]
-                      suboptions:
-                        origin:
-                          description:
-                             - Set AS as origin.
-                          type: bool
-                        value:
-                          description:
-                            - Holds AS number in the range 1-10.
-                          type: int
-        neighbors:
-          description:
-            - Specifies BGP neighbor related configurations.
-          type: list
-          elements: dict
-          suboptions:
-            neighbor:
-              description:
-                - Neighbor router address.
-              type: str
-              required: True
-            remote_as:
-              description:
-                - Remote AS of the BGP neighbor to configure.
-              type: dict
-              mutually_exclusive: [['peer_as','peer_type']]
-              suboptions:
-                peer_as:
-                  description:
-                    - Specifies remote AS number.
-                    - The range is from 1 to 4294967295.
-                  type: int
-                peer_type:
-                  description:
-                    - Specifies type of bgp peer.
-                  type: str
-                  choices: ['internal', 'external']
-            bfd:
-              description:
-                - Enable or disable bfd.
-              type: bool
-            advertisement_interval:
-              description:
-                - Specifies the minimum interval between sending BGP routing updates.
-                - The range is from 0 to 600.
-              type: int
-            peer_group:
-              description:
-                - Name of the peer group that the neighbor is a member of.
-              type: str
-            timers:
-              description:
-                - Specifies BGP neighbor timer related configurations.
-              type: dict
-              suboptions:
-                keepalive:
-                  description:
-                    - Frequency (in seconds) with which the device sends keepalive messages to its peer.
-                    - The range is from 0 to 65535.
-                  type: int
-                holdtime:
-                  description:
-                    - Interval (in seconds) after not receiving a keepalive message that SONiC declares a peer dead.
-                    - The range is from 0 to 65535.
-                  type: int
-            capability:
-              description:
-                - Specifies capability attributes to this neighbor.
-              type: dict
-              suboptions:
-                dynamic:
-                  description:
-                    - Enable or disable dynamic capability to this neighbor.
-                  type: bool
-                extended_nexthop:
-                  description:
-                    - Enable or disable advertise extended next-hop capability to the peer.
-                  type: bool
     state:
       description:
         - Specifies the operation to be performed on the BGP process configured on the device.

--- a/models/enterprise_sonic/bgp_neighbors/sonic_bgp_neighbors.yaml
+++ b/models/enterprise_sonic/bgp_neighbors/sonic_bgp_neighbors.yaml
@@ -68,7 +68,7 @@ DOCUMENTATION: |
               suboptions:
                 enabled:
                   description:
-                    - Enables BFD liveliness check for a BGP peer.
+                    - Enables BFD liveness check for a BGP peer.
                   type: bool
                 check_failure:
                   description:
@@ -293,7 +293,7 @@ DOCUMENTATION: |
               suboptions:
                 enabled:
                   description:
-                    - Enables BFD liveliness check for a BGP neighbor.
+                    - Enables BFD liveness check for a BGP neighbor.
                   type: bool
                 check_failure:
                   description:

--- a/models/enterprise_sonic/bgp_neighbors/sonic_bgp_neighbors.yaml
+++ b/models/enterprise_sonic/bgp_neighbors/sonic_bgp_neighbors.yaml
@@ -64,7 +64,20 @@ DOCUMENTATION: |
             bfd:
               description:
                 - Enable or disable bfd.
-              type: bool
+              type: dict
+              suboptions:
+                enabled:
+                  description:
+                    - Enables BFD liveliness check for a BGP peer.
+                  type: bool
+                check_failure:
+                  description:
+                    - Link dataplane status with control plane.
+                  type: bool
+                profile:
+                  description:
+                    - BFD Profile name format.
+                  type: str
             advertisement_interval:
               description:
                 - Specifies the minimum interval between sending BGP routing updates.
@@ -85,6 +98,11 @@ DOCUMENTATION: |
                     - Interval (in seconds) after not receiving a keepalive message that SONiC declares a peer dead.
                     - The range is from 0 to 65535.
                   type: int
+                connect_retry:
+                  description:
+                    - Time interval in seconds between attempts to establish a session with the peer.
+                    - The range is from 1 to 65535.
+                  type: int
             capability:
               description:
                 - Specifies capability attributes to this peergroup.
@@ -98,6 +116,102 @@ DOCUMENTATION: |
                   description:
                     - Enable or disable advertise extended next-hop capability to the peer.
                   type: bool
+            auth_pwd:
+              description:
+                - Configuration for peer group authentication password.
+              type: dict
+              suboptions:
+                pwd:
+                  description:
+                    - Authentication password for the peer group.
+                  type: str
+                  required: True
+                encrypted:
+                  description:
+                    - Indicates whether the password is encrypted text.
+                  type: bool
+                  default: False
+            pg_description:
+              description:
+                - A textual description of the interface.
+              type: str
+            disable_connected_check:
+              description:
+                - Disables EBGP conntected route check.
+              type: bool
+            dont_negotiate_capability:
+              description:
+                - Disables capability negotiation.
+              type: bool
+            ebgp_multihop:
+              description:
+                - Allow EBGP peers not on directly connected networks.
+              type: dict
+              suboptions:
+                enabled:
+                  description:
+                    - Enables the referenced group or peers to be indirectly connected.
+                  type: bool
+                  default: False
+                multihop_ttl:
+                  description:
+                    - Time-to-live value to use when packets are sent to the referenced group or peers and ebgp-multihop is enabled.
+                  type: int
+            enforce_first_as:
+              description:
+                - Enforces the first AS for EBGP routes.
+              type: bool
+            enforce_multihop:
+              description:
+                - Enforces EBGP multihop performance for peer.
+              type: bool
+            local_address:
+              description:
+                - Set the local IP address to use for the session when sending BGP update messages.
+              type: str
+            local_as:
+              description:
+                - Specifies local autonomous system number.
+              type: dict
+              suboptions:
+                as:
+                  description:
+                    - Local autonomous system number.
+                  type: int
+                  required: True
+                no_prepend:
+                  description:
+                    - Do not prepend the local-as number in AS-Path advertisements.
+                  type: bool
+                replace_as:
+                  description:
+                    - Replace the configured AS Number with the local-as number in AS-Path advertisements.
+                  type: bool
+            override_capability:
+              description:
+                - Override capability negotiation result.
+              type: bool
+            passive:
+              description:
+                - Do not send open messages to this peer.
+              type: bool
+              default: False
+            shutdown_msg:
+              description:
+                - Add a shutdown message.
+              type: str
+            solo:
+              description:
+                - Indicates that routes advertised by the peer should not be reflected back to the peer.
+              type: bool
+            strict_capability_match:
+              description:
+                - Enables strict capability negotiation match.
+              type: bool
+            ttl_security:
+              description:
+                - Enforces only the peers that are specified number of hops away will be allowed to become peers.
+              type: int
             address_family:
               description:
                 - Holds of list of address families associated to the peergroup.

--- a/models/enterprise_sonic/bgp_neighbors/sonic_bgp_neighbors.yaml
+++ b/models/enterprise_sonic/bgp_neighbors/sonic_bgp_neighbors.yaml
@@ -76,7 +76,7 @@ DOCUMENTATION: |
                   type: bool
                 profile:
                   description:
-                    - BFD Profile name format.
+                    - BFD Profile name.
                   type: str
             advertisement_interval:
               description:
@@ -133,7 +133,7 @@ DOCUMENTATION: |
                   default: False
             pg_description:
               description:
-                - A textual description of the interface.
+                - A textual description of the peer group.
               type: str
             disable_connected_check:
               description:
@@ -301,7 +301,7 @@ DOCUMENTATION: |
                   type: bool
                 profile:
                   description:
-                    - BFD Profile name format.
+                    - BFD Profile name.
                   type: str
             advertisement_interval:
               description:
@@ -361,7 +361,7 @@ DOCUMENTATION: |
                   default: False
             nbr_description:
               description:
-                - A textual description of the interface.
+                - A textual description of the neighbor.
               type: str
             disable_connected_check:
               description:


### PR DESCRIPTION
I updated the configuration examples to include the attributes that were added to the sonic_bgp_neighbors module.