### PR TITLE
Define the "dhcp_relay" model for the Dell Enterprise SONiC collection

### DIFF
--- a/models/enterprise_sonic/dhcp_relay/deleted_example_01.txt
+++ b/models/enterprise_sonic/dhcp_relay/deleted_example_01.txt
@@ -1,0 +1,79 @@
+# Using deleted
+#
+# Before State:
+# -------------
+#
+# sonic# show running-configuration interface
+# !
+# interface Eth1/1
+#  mtu 9100
+#  speed 400000
+#  fec RS
+#  no shutdown
+#  ip address 81.1.1.1/24
+#  ip dhcp-relay 91.1.1.1 92.1.1.1 vrf VrfReg1
+#  ip dhcp-relay max-hop-count 5
+#  ip dhcp-relay vrf-select
+#  ip dhcp-relay policy-action append
+#  ipv6 address 81::1/24
+#  ipv6 dhcp-relay 91::1 92::1
+#  ipv6 dhcp-relay max-hop-count 5
+# !
+# interface Eth1/2
+#  mtu 9100
+#  speed 400000
+#  fec RS
+#  no shutdown
+#  ip address 61.1.1.1/24
+#  ip dhcp-relay 71.1.1.1 72.1.1.1 73.1.1.1
+#  ip dhcp-relay source-interface Vlan100
+#  ip dhcp-relay link-select
+#  ip dhcp-relay circuit-id %h:%p
+# !
+
+  - name: Delete DHCP and DHCPv6 relay configurations
+    dellemc.enterprise_sonic.sonic_dhcp_relay:
+      config:
+        - name: 'Eth1/1'
+          ipv4:
+            server_addresses:
+              - address: '92.1.1.1'
+            vrf_select: true
+            max_hop_count: 5
+          ipv6:
+            server_addresses:
+              - address: '91::1'
+              - address: '92::1'
+        - name: 'Eth1/2'
+          ipv4:
+            server_addresses:
+              - address: '71.1.1.1'
+              - address: '72.1.1.1'
+            source_interface: 'Vlan100'
+            link_select: true
+            circuit_id: '%h:%p'
+      state: deleted
+
+# After State:
+# ------------
+#
+# sonic# show running-configuration interface
+# !
+# interface Eth1/1
+#  mtu 9100
+#  speed 400000
+#  fec RS
+#  no shutdown
+#  ip address 81.1.1.1/24
+#  ip dhcp-relay 91.1.1.1 vrf VrfReg1
+#  ip dhcp-relay policy-action append
+#  ipv6 address 81::1/24
+# !
+# interface Eth1/2
+#  mtu 9100
+#  speed 400000
+#  fec RS
+#  no shutdown
+#  ip address 61.1.1.1/24
+#  ip dhcp-relay 73.1.1.1
+# !

--- a/models/enterprise_sonic/dhcp_relay/deleted_example_02.txt
+++ b/models/enterprise_sonic/dhcp_relay/deleted_example_02.txt
@@ -1,0 +1,58 @@
+# Using deleted
+#
+# Before State:
+# -------------
+#
+# sonic# show running-configuration interface
+# !
+# interface Eth1/1
+#  mtu 9100
+#  speed 400000
+#  fec RS
+#  no shutdown
+#  ip address 81.1.1.1/24
+#  ip dhcp-relay 91.1.1.1 92.1.1.1 vrf VrfReg1
+#  ip dhcp-relay max-hop-count 5
+#  ip dhcp-relay vrf-select
+#  ip dhcp-relay policy-action append
+#  ipv6 address 81::1/24
+#  ipv6 dhcp-relay 91::1 92::1
+#  ipv6 dhcp-relay max-hop-count 5
+# !
+# interface Eth1/2
+#  mtu 9100
+#  speed 400000
+#  fec RS
+#  no shutdown
+#  ip address 61.1.1.1/24
+#  ip dhcp-relay 71.1.1.1 72.1.1.1 73.1.1.1
+#  ip dhcp-relay source-interface Vlan100
+#  ip dhcp-relay link-select
+#  ip dhcp-relay circuit-id %h:%p
+# !
+
+  - name: Delete all DHCP and DHCPv6 relay configurations
+    dellemc.enterprise_sonic.sonic_dhcp_relay:
+      config:
+      state: deleted
+
+# After State:
+# ------------
+#
+# sonic# show running-configuration interface
+# !
+# interface Eth1/1
+#  mtu 9100
+#  speed 400000
+#  fec RS
+#  no shutdown
+#  ip address 81.1.1.1/24
+#  ipv6 address 81::1/24
+# !
+# interface Eth1/2
+#  mtu 9100
+#  speed 400000
+#  fec RS
+#  no shutdown
+#  ip address 61.1.1.1/24
+# !

--- a/models/enterprise_sonic/dhcp_relay/deleted_example_02.txt
+++ b/models/enterprise_sonic/dhcp_relay/deleted_example_02.txt
@@ -31,7 +31,7 @@
 #  ip dhcp-relay circuit-id %h:%p
 # !
 
-  - name: Delete all DHCP relay configurations for interface Eth1/1
+  - name: Delete all IPv4 DHCP relay configurations for interface Eth1/1
     dellemc.enterprise_sonic.sonic_dhcp_relay:
       config:
         - name: 'Eth1/1'

--- a/models/enterprise_sonic/dhcp_relay/deleted_example_03.txt
+++ b/models/enterprise_sonic/dhcp_relay/deleted_example_03.txt
@@ -31,13 +31,10 @@
 #  ip dhcp-relay circuit-id %h:%p
 # !
 
-  - name: Delete all DHCP relay configurations for interface Eth1/1
+  - name: Delete all DHCP and DHCPv6 relay configurations for interface Eth1/1
     dellemc.enterprise_sonic.sonic_dhcp_relay:
       config:
         - name: 'Eth1/1'
-          ipv4:
-            server_addresses:
-              - address:
       state: deleted
 
 # After State:
@@ -52,8 +49,6 @@
 #  no shutdown
 #  ip address 81.1.1.1/24
 #  ipv6 address 81::1/24
-#  ipv6 dhcp-relay 91::1 92::1
-#  ipv6 dhcp-relay max-hop-count 5
 # !
 # interface Eth1/2
 #  mtu 9100

--- a/models/enterprise_sonic/dhcp_relay/deleted_example_04.txt
+++ b/models/enterprise_sonic/dhcp_relay/deleted_example_04.txt
@@ -31,13 +31,9 @@
 #  ip dhcp-relay circuit-id %h:%p
 # !
 
-  - name: Delete all DHCP relay configurations for interface Eth1/1
+  - name: Delete all DHCP and DHCPv6 relay configurations
     dellemc.enterprise_sonic.sonic_dhcp_relay:
       config:
-        - name: 'Eth1/1'
-          ipv4:
-            server_addresses:
-              - address:
       state: deleted
 
 # After State:
@@ -52,8 +48,6 @@
 #  no shutdown
 #  ip address 81.1.1.1/24
 #  ipv6 address 81::1/24
-#  ipv6 dhcp-relay 91::1 92::1
-#  ipv6 dhcp-relay max-hop-count 5
 # !
 # interface Eth1/2
 #  mtu 9100
@@ -61,8 +55,4 @@
 #  fec RS
 #  no shutdown
 #  ip address 61.1.1.1/24
-#  ip dhcp-relay 71.1.1.1 72.1.1.1 73.1.1.1
-#  ip dhcp-relay source-interface Vlan100
-#  ip dhcp-relay link-select
-#  ip dhcp-relay circuit-id %h:%p
 # !

--- a/models/enterprise_sonic/dhcp_relay/merged_example_01.txt
+++ b/models/enterprise_sonic/dhcp_relay/merged_example_01.txt
@@ -1,0 +1,80 @@
+# Using merged
+#
+# Before State:
+# -------------
+#
+# sonic# show running-configuration interface
+# !
+# interface Eth1/1
+#  mtu 9100
+#  speed 400000
+#  fec RS
+#  no shutdown
+#  ip address 81.1.1.1/24
+#  ipv6 address 81::1/24
+# !
+# interface Eth1/2
+#  mtu 9100
+#  speed 400000
+#  fec RS
+#  no shutdown
+#  ip address 61.1.1.1/24
+#  ip dhcp-relay 71.1.1.1 72.1.1.1
+# !
+
+  - name: Add DHCP and DHCPv6 relay configurations
+    dellemc.enterprise_sonic.sonic_dhcp_relay:
+      config:
+        - name: 'Eth1/1'
+          ipv4:
+            server_addresses:
+              - address: '91.1.1.1'
+              - address: '92.1.1.1'
+            vrf_name: 'VrfReg1'
+            vrf_select: true
+            max_hop_count: 5
+            policy_action: 'append'
+          ipv6:
+            server_addresses:
+              - address: '91::1'
+              - address: '92::1'
+            max_hop_count: 5
+        - name: 'Eth1/2'
+          ipv4:
+            server_addresses:
+              - address: '73.1.1.1'
+            source_interface: 'Vlan100'
+            link_select: true
+            circuit_id: '%h:%p'
+      state: merged
+
+# After State:
+# ------------
+#
+# sonic# show running-configuration interface
+# !
+# interface Eth1/1
+#  mtu 9100
+#  speed 400000
+#  fec RS
+#  no shutdown
+#  ip address 81.1.1.1/24
+#  ip dhcp-relay 91.1.1.1 92.1.1.1 vrf VrfReg1
+#  ip dhcp-relay max-hop-count 5
+#  ip dhcp-relay vrf-select
+#  ip dhcp-relay policy-action append
+#  ipv6 address 81::1/24
+#  ipv6 dhcp-relay 91::1 92::1
+#  ipv6 dhcp-relay max-hop-count 5
+# !
+# interface Eth1/2
+#  mtu 9100
+#  speed 400000
+#  fec RS
+#  no shutdown
+#  ip address 61.1.1.1/24
+#  ip dhcp-relay 71.1.1.1 72.1.1.1 73.1.1.1
+#  ip dhcp-relay source-interface Vlan100
+#  ip dhcp-relay link-select
+#  ip dhcp-relay circuit-id %h:%p
+# !

--- a/models/enterprise_sonic/dhcp_relay/sonic_dhcp_relay.yml
+++ b/models/enterprise_sonic/dhcp_relay/sonic_dhcp_relay.yml
@@ -131,4 +131,6 @@ DOCUMENTATION: |
 EXAMPLES:
   - deleted_example_01.txt
   - deleted_example_02.txt
+  - deleted_example_03.txt
+  - deleted_example_04.txt
   - merged_example_01.txt

--- a/models/enterprise_sonic/dhcp_relay/sonic_dhcp_relay.yml
+++ b/models/enterprise_sonic/dhcp_relay/sonic_dhcp_relay.yml
@@ -1,0 +1,134 @@
+---
+GENERATOR_VERSION: '1.0'
+ANSIBLE_METADATA: |
+    {
+        'metadata_version': '1.1',
+        'status': ['preview'],
+        'supported_by': 'community',
+        'license': 'Apache 2.0'
+    }
+NETWORK_OS: sonic
+RESOURCE: dhcp_relay
+COPYRIGHT: Copyright 2022 Dell Inc. or its subsidiaries. All Rights Reserved
+DOCUMENTATION: |
+    module: sonic_dhcp_relay
+    version_added: '2.1.0'
+    short_description: Manage DHCP and DHCPv6 relay configurations on SONiC
+    description:
+      - This module provides configuration management of DHCP and DHCPv6 relay
+        parameters on Layer 3 interfaces of devices running SONiC.
+      - Layer 3 interface and VRF name need to be created earlier in the device.
+    author: 'Arun Saravanan Balachandran (@ArunSaravananBalachandran)'
+    options:
+      config:
+        description:
+          - Specifies the DHCP and DHCPv6 relay configurations.
+        type: list
+        elements: dict
+        suboptions:
+          name:
+            description:
+              - Full name of the Layer 3 interface, i.e. Eth1/1.
+            type: str
+            required: true
+          ipv4:
+            description:
+              - DHCP relay configurations to be set for the interface mentioned in name option.
+            type: dict
+            suboptions:
+              server_addresses:
+                description:
+                  - List of DHCP server IPv4 addresses.
+                type: list
+                elements: dict
+                suboptions:
+                  address:
+                    description:
+                      - IPv4 address of the DHCP server.
+                    type: str
+              vrf_name:
+                description:
+                  - Specifies name of the VRF in which the DHCP server resides.
+                  - This option is used only with state I(merged).
+                type: str
+              source_interface:
+                description:
+                  - Specifies the DHCP relay source interface.
+                type: str
+              max_hop_count:
+                description:
+                  - Specifies the maximum hop count for DHCP relay packets.
+                  - The range is from 1 to 16.
+                type: int
+              link_select:
+                description:
+                  - Enable link selection suboption.
+                type: bool
+              vrf_select:
+                description:
+                  - Enable VRF selection suboption.
+                type: bool
+              circuit_id:
+                description:
+                  - Specifies the DHCP relay circuit-id format.
+                  - C(%h:%p) - Hostname followed by interface name eg. sonic:Vlan100
+                  - C(%i) - Name of the physical interface eg. Eth1/2
+                  - C(%p) - Name of the interface eg. Vlan100
+                type: str
+                choices:
+                  - '%h:%p'
+                  - '%i'
+                  - '%p'
+              policy_action:
+                description:
+                  - Specifies the policy for handling of DHCP relay options.
+                type: str
+                choices:
+                  - append
+                  - discard
+                  - replace
+          ipv6:
+            description:
+              - DHCPv6 relay configurations to be set for the interface mentioned in name option.
+            type: dict
+            suboptions:
+              server_addresses:
+                description:
+                  - List of DHCPv6 server IPv6 addresses.
+                type: list
+                elements: dict
+                suboptions:
+                  address:
+                    description:
+                      - IPv6 address of the DHCPv6 server.
+                    type: str
+              vrf_name:
+                description:
+                  - Specifies name of the VRF in which the DHCPv6 server resides.
+                  - This option is used only with state I(merged).
+                type: str
+              source_interface:
+                description:
+                  - Specifies the DHCPv6 relay source interface.
+                type: str
+              max_hop_count:
+                description:
+                  - Specifies the maximum hop count for DHCPv6 relay packets.
+                  - The range is from 1 to 16.
+                type: int
+              vrf_select:
+                description:
+                  - Enable VRF selection suboption.
+                type: bool
+      state:
+        description:
+          - The state of the configuration after module completion.
+        type: str
+        choices:
+          - merged
+          - deleted
+        default: merged
+EXAMPLES:
+  - deleted_example_01.txt
+  - deleted_example_02.txt
+  - merged_example_01.txt


### PR DESCRIPTION
Initial posting for the "dhcp_relay" model definition.