### PR TITLE
Make NTP minpoll and maxpoll config together

### DIFF
--- a/models/enterprise_sonic/ntp/sonic_ntp.yaml
+++ b/models/enterprise_sonic/ntp/sonic_ntp.yaml
@@ -47,7 +47,7 @@ DOCUMENTATION: |
             required_together: [['minpoll', 'maxpoll']]
             description:
               - List of NTP servers.
-              - minpoll and maxpoll are required to configure together.
+              - minpoll and maxpoll are required to be configured together.
             suboptions:
               address:
                 type: str

--- a/models/enterprise_sonic/ntp/sonic_ntp.yaml
+++ b/models/enterprise_sonic/ntp/sonic_ntp.yaml
@@ -44,8 +44,10 @@ DOCUMENTATION: |
           servers:
             type: list
             elements: dict
+            required_together: [['minpoll', 'maxpoll']]
             description:
               - List of NTP servers.
+              - minpoll and maxpoll are required to configure together.
             suboptions:
               address:
                 type: str


### PR DESCRIPTION
This is to make NTP server minpoll and maxpoll attributes be configured together. This is required by SONIC.