### PR TITLE
Add support for private vlan configuration to ios_vlans

### DIFF
--- a/models/ios/vlans/ios_vlans.yaml
+++ b/models/ios/vlans/ios_vlans.yaml
@@ -53,6 +53,26 @@ DOCUMENTATION: |
           description:
           - Shutdown VLAN switching.
           type: bool
+        private_vlan:
+          description:
+            - Private VLAN configuration options.
+          suboptions:
+            type:
+              description:
+                - Private VLAN type
+              type: str
+              choices:
+                - primary
+                - isolated
+                - community
+            association:
+              description:
+                - This option is used only with type I(primary)
+                - Isolated or community private VLANs that are associated with this VLAN
+              type: list
+              elements: int
+          type: dict
+          
     state:
       description:
       - The state the configuration should be left in

--- a/models/ios/vlans/ios_vlans.yaml
+++ b/models/ios/vlans/ios_vlans.yaml
@@ -55,11 +55,11 @@ DOCUMENTATION: |
           type: bool
         private_vlan:
           description:
-            - Private VLAN configuration options.
+          - Private VLAN configuration options.
           suboptions:
             type:
               description:
-                - Private VLAN type
+              - Private VLAN type
               type: str
               choices:
                 - primary
@@ -67,8 +67,8 @@ DOCUMENTATION: |
                 - community
             association:
               description:
-                - This option is used only with type I(primary)
-                - Isolated or community private VLANs that are associated with this VLAN
+              - This option is used only with type I(primary)
+              - Isolated or community private VLANs that are associated with this VLAN
               type: list
               elements: int
           type: dict

--- a/models/ios/vlans/ios_vlans.yaml
+++ b/models/ios/vlans/ios_vlans.yaml
@@ -72,7 +72,6 @@ DOCUMENTATION: |
               type: list
               elements: int
           type: dict
-          
     state:
       description:
       - The state the configuration should be left in

--- a/models/ios/vlans/override_example_01.txt
+++ b/models/ios/vlans/override_example_01.txt
@@ -36,17 +36,59 @@
       - name: Vlan_10
         vlan_id: 10
         mtu: 1000
+      - name: pvlan-isolated
+        vlan_id: 50
+	private-vlan:
+	  type: isolated
+      - name: pvlan-community
+        vlan_id: 51
+	private-vlan:
+	  type: community
+      - name: pvnal-primary
+        vlan_id: 59
+	private-vlan:
+	  type: primary
+	  association:
+	    - 50
+	    - 51
     state: overridden
 
 # After state:
 # ------------
-#
-# vios#show vlan
+# 
+# vios# show vlan
 # VLAN Name                             Status    Ports
 # ---- -------------------------------- --------- -------------------------------
-# 10   Vlan_10                          active
-#
+# 1    default                          active    Gi0/1, Gi0/2
+# 10   Vlan_10                          active    
+# 50   pvlan-isolated                   active    
+# 51   pvlan-community                  active    
+# 59   pvlan-primary                    active    
+# 1002 fddi-default                     act/unsup 
+# 1003 token-ring-default               act/unsup 
+# 1004 fddinet-default                  act/unsup 
+# 1005 trnet-default                    act/unsup 
+# 
 # VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
 # ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
-# 10   enet  100010     1000  -      -      -        -    -        0      0
-
+# 1    enet  100001     1500  -      -      -        -    -        0      0   
+# 10   enet  100010     1000  -      -      -        -    -        0      0   
+# 50   enet  100050     1500  -      -      -        -    -        0      0   
+# 51   enet  100051     1500  -      -      -        -    -        0      0   
+# 59   enet  100059     1500  -      -      -        -    -        0      0   
+# 1002 fddi  101002     1500  -      -      -        -    -        0      0   
+# 1003 tr    101003     1500  -      -      -        -    -        0      0   
+# 1004 fdnet 101004     1500  -      -      -        ieee -        0      0   
+#           
+# VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
+# ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
+# 1005 trnet 101005     1500  -      -      -        ibm  -        0      0   
+# 
+# Remote SPAN VLANs
+# ------------------------------------------------------------------------------
+#
+#
+# Primary Secondary Type              Ports
+# ------- --------- ----------------- ------------------------------------------
+# 59      50        isolated          
+# 59      51        community

--- a/models/ios/vlans/override_example_01.txt
+++ b/models/ios/vlans/override_example_01.txt
@@ -55,8 +55,8 @@
 
 # After state:
 # ------------
-# 
-# vios# show vlan
+#
+# vios#show vlan
 # VLAN Name                             Status    Ports
 # ---- -------------------------------- --------- -------------------------------
 # 1    default                          active    Gi0/1, Gi0/2


### PR DESCRIPTION
Proposed model for supporting private vlan configuration to the ios_vlans module

Working on feature request for ansible-collections/cisco.ios#690 