### PR TITLE
Modify the model to allow configuration of vlan trunk ranges

### DIFF
--- a/models/enterprise_sonic/l2_interfaces/deleted_example_03.txt
+++ b/models/enterprise_sonic/l2_interfaces/deleted_example_03.txt
@@ -6,10 +6,14 @@
 do show Vlan
 Q: A - Access (Untagged), T - Tagged
 NUM        Status      Q Ports
-10         Inactive    A  Ethernet12
+12         Inactive    A  Ethernet12
 11         Inactive    T  Ethernet12
+13         Inactive    T  Ethernet12
+14         Inactive    T  Ethernet12
+15         Inactive    T  Ethernet12
+16         Inactive    T  Ethernet12
 
-- name: Modify tha access vlan and add a range of trunk vlans
+- name: Delete the access vlan and a range of trunk vlans
   sonic_l2_interfaces:
     config:
       - name: Ethernet12
@@ -18,7 +22,7 @@ NUM        Status      Q Ports
         trunk: 
           allowed_vlans:
              - vlan: 13-16
-    state: merged
+    state: deleted
 
 # After state:
 # ------------
@@ -26,9 +30,4 @@ NUM        Status      Q Ports
 do show Vlan
 Q: A - Access (Untagged), T - Tagged
 NUM        Status      Q Ports
-12         Inactive    A  Ethernet12
 11         Inactive    T  Ethernet12
-13         Inactive    T  Ethernet12
-14         Inactive    T  Ethernet12
-15         Inactive    T  Ethernet12
-16         Inactive    T  Ethernet12

--- a/models/enterprise_sonic/l2_interfaces/sonic_l2_interfaces.yml
+++ b/models/enterprise_sonic/l2_interfaces/sonic_l2_interfaces.yml
@@ -38,8 +38,8 @@ DOCUMENTATION: |
                 elements: dict
                 suboptions:
                   vlan:
-                    type: int
-                    description: 'This is a vlan in trunk mode'
+                    type: str
+                    description: 'This is a vlan 'x' or vlan range 'x-y' in trunk mode'
           access:
             type: dict
             description: 'It is a access mode configuration of the l2_interfaces'


### PR DESCRIPTION
- Change the trunk vlan argument type from "int" to "str".
- Update the trunk vlan argument description to include vlan ranges.
- Add "merged" and "deleted" examples for vlan trunk ranges.