### PR TITLE
Add replaced and overridden states to VRFS model

### DIFF
--- a/models/enterprise_sonic/vrfs/overridden_example_01.txt
+++ b/models/enterprise_sonic/vrfs/overridden_example_01.txt
@@ -1,0 +1,39 @@
+# Using overridden
+#
+# Before state:
+# -------------
+#
+show ip vrf
+VRF-NAME            INTERFACES
+----------------------------------------------------------------
+Vrfcheck1
+Vrfcheck2
+Vrfcheck3           Ethernet60
+                    Ethernet64
+
+- name: Overridden VRF configuration
+  sonic_vrfs:
+    config:
+      - name: Vrfcheck1
+        members:
+          interfaces:
+            - name: Ethernet24
+            - name: Ethernet28
+      - name: Vrfcheck3
+        members:
+          interfaces:
+            - name: Ethernet12
+            - name: Ethernet52
+    state: overridden
+
+# After state:
+# ------------
+#
+show ip vrf
+VRF-NAME            INTERFACES
+----------------------------------------------------------------
+Vrfcheck1           Ethernet24
+                    Ethernet28
+Vrfcheck2
+Vrfcheck3           Ethernet12
+                    Ethernet52

--- a/models/enterprise_sonic/vrfs/replaced_example_01.txt
+++ b/models/enterprise_sonic/vrfs/replaced_example_01.txt
@@ -1,0 +1,39 @@
+# Using replaced
+#
+# Before state:
+# -------------
+#
+show ip vrf
+VRF-NAME            INTERFACES
+----------------------------------------------------------------
+Vrfcheck1           Ethernet24
+Vrfcheck2
+Vrfcheck3           Ethernet60
+                    Ethernet64
+
+- name: Replace VRF configuration
+  sonic_vrfs:
+    config:
+      - name: Vrfcheck1
+        members:
+          interfaces:
+            - name: Ethernet24
+            - name: Ethernet28
+      - name: Vrfcheck3
+        members:
+          interfaces:
+            - name: Ethernet12
+            - name: Ethernet52
+    state: replaced
+
+# After state:
+# ------------
+#
+show ip vrf
+VRF-NAME            INTERFACES
+----------------------------------------------------------------
+Vrfcheck1           Ethernet24
+                    Ethernet28
+Vrfcheck2
+Vrfcheck3           Ethernet12
+                    Ethernet52

--- a/models/enterprise_sonic/vrfs/sonic_vrfs.yaml
+++ b/models/enterprise_sonic/vrfs/sonic_vrfs.yaml
@@ -42,8 +42,12 @@ DOCUMENTATION: |
         type: str
         choices:
         - merged
+        - replaced
+        - overridden
         - deleted
         default: merged
 EXAMPLES:
   - deleted_example_01.txt
   - merged_example_01.txt
+  - overridden_example_01.txt
+  - replaced_example_01.txt


### PR DESCRIPTION
This to add "replaced" and "overridden" states to sonic_vrfs resource model.