### PR TITLE
Add replaced and overridden states to System model

### DIFF
--- a/models/enterprise_sonic/system/overridden_example_01.txt
+++ b/models/enterprise_sonic/system/overridden_example_01.txt
@@ -1,0 +1,29 @@
+# Using overridden
+#
+# Before state:
+# -------------
+#!
+#sonic(config)#do show running-configuration
+#!
+#ip anycast-mac-address aa:bb:cc:dd:ee:ff
+#ip anycast-address enable
+#ipv6 anycast-address enable
+
+    - name: Override system configuration.
+      sonic_system:
+        config:
+          hostname: sonic
+          interface_naming: standard
+          anycast_address:
+            ipv4: true
+            mac_address: bb:aa:cc:dd:ee:ff
+        state: overridden
+
+# After state:
+# ------------
+#!
+#SONIC(config)#do show running-configuration
+#!
+#ip anycast-mac-address bb:aa:cc:dd:ee:ff
+#ip anycast-address enable
+#interface-naming standard

--- a/models/enterprise_sonic/system/replaced_example_01.txt
+++ b/models/enterprise_sonic/system/replaced_example_01.txt
@@ -1,0 +1,24 @@
+# Using replaced
+#
+# Before state:
+# -------------
+#!
+#sonic(config)#do show running-configuration
+#!
+#ip anycast-mac-address aa:bb:cc:dd:ee:ff
+#ip anycast-address enable
+#ipv6 anycast-address enable
+
+    - name: Replace system configuration.
+      sonic_system:
+        config:
+          hostname: sonic
+          interface_naming: standard
+        state: replaced
+
+# After state:
+# ------------
+#!
+#SONIC(config)#do show running-configuration
+#!
+#interface-naming standard

--- a/models/enterprise_sonic/system/replaced_example_02.txt
+++ b/models/enterprise_sonic/system/replaced_example_02.txt
@@ -1,0 +1,28 @@
+# Using replaced
+#
+# Before state:
+# -------------
+#!
+#sonic(config)#do show running-configuration
+#!
+#ip anycast-mac-address aa:bb:cc:dd:ee:ff
+#interface-naming standard
+
+    - name: Replace system device configuration.
+      sonic_system:
+        config:
+          hostname: sonic
+          interface_naming: standard
+          anycast_address:
+            ipv6: true
+            ipv4: true
+        state: replaced
+
+# After state:
+# ------------
+#!
+#SONIC(config)#do show running-configuration
+#!
+#ip anycast-address enable
+#ipv6 anycast-address enable
+#interface-naming standard

--- a/models/enterprise_sonic/system/sonic_system.yaml
+++ b/models/enterprise_sonic/system/sonic_system.yaml
@@ -56,8 +56,11 @@ DOCUMENTATION: |
         - In case of merged, the input configuration will be merged with the existing system configuration on the device.
         - In case of deleted the existing system configuration will be removed from the device.
       default: merged
-      choices: ['merged', 'deleted']
+      choices: ['merged', 'replaced', 'overridden', 'deleted']
 EXAMPLES:
   - deleted_example_01.txt
   - deleted_example_02.txt
   - merged_example_01.txt
+  - replaced_example_01.txt
+  - replaced_example_02.txt
+  - overridden_example_01.txt


### PR DESCRIPTION
This is to add "replaced" and "overridden" states to sonic_system resource model.