### PR TITLE
Add replaced and overridden states for TACACS server

### DIFF
--- a/models/enterprise_sonic/tacacs_server/overridden_example_01.txt
+++ b/models/enterprise_sonic/tacacs_server/overridden_example_01.txt
@@ -1,0 +1,54 @@
+# Using overridden
+#
+# Before state:
+# -------------
+#
+#sonic(config)# do show tacacs-server
+#---------------------------------------------------------
+#TACACS Global Configuration
+#---------------------------------------------------------
+#source-interface  : Ethernet12
+#timeout           : 10
+#auth-type         : pap
+#key configured    : Yes
+#--------------------------------------------------------------------------------------
+#HOST                 AUTH-TYPE    KEY-CONFIG PORT       PRIORITY   TIMEOUT    VRF
+#--------------------------------------------------------------------------------------
+#1.2.3.4              pap          No         49         1          5          default
+#11.12.13.14          chap         Yes        49         10         5          default
+#
+- name: Overridden tacacs configurations
+  sonic_tacacs_server:
+    config:
+      auth_type: mschap
+      key: mschap
+      source_interface: Ethernet12
+      timeout: 20
+      servers:
+        - host:
+            name: 1.2.3.4
+            auth_type: mschap
+            key: mschap
+        - host:
+            name: 10.10.11.12
+            auth_type: chap
+            timeout: 30
+            priority: 2
+    state: overridden
+#
+# After state:
+# ------------
+#
+#sonic(config)# do show tacacs-server
+#---------------------------------------------------------
+#TACACS Global Configuration
+#---------------------------------------------------------
+#source-interface  : Ethernet12
+#timeout           : 20
+#auth-type         : mschap
+#key configured    : Yes
+#--------------------------------------------------------------------------------------
+#HOST                 AUTH-TYPE    KEY-CONFIG PORT       PRIORITY   TIMEOUT    VRF
+#--------------------------------------------------------------------------------------
+#1.2.3.4              mschap       Yes        49         1          5          default
+#10.10.11.12          chap         No         49         2          30         default

--- a/models/enterprise_sonic/tacacs_server/replaced_example_01.txt
+++ b/models/enterprise_sonic/tacacs_server/replaced_example_01.txt
@@ -1,0 +1,47 @@
+# Using replaced
+#
+# Before state:
+# -------------
+#
+#sonic(config)# do show tacacs-server
+#---------------------------------------------------------
+#TACACS Global Configuration
+#---------------------------------------------------------
+#source-interface  : Ethernet12
+#timeout           : 10
+#auth-type         : pap
+#key configured    : Yes
+#--------------------------------------------------------------------------------------
+#HOST                 AUTH-TYPE    KEY-CONFIG PORT       PRIORITY   TIMEOUT    VRF
+#--------------------------------------------------------------------------------------
+#1.2.3.4              pap          No         49         1          5          default
+#
+- name: Replace tacacs configurations
+  sonic_tacacs_server:
+    config:
+      auth_type: pap
+      key: pap
+      source_interface: Ethernet12
+      timeout: 10
+      servers:
+        - host:
+            name: 1.2.3.4
+            auth_type: mschap
+            key: 1234
+    state: replaced
+#
+# After state:
+# ------------
+#
+#sonic(config)# do show tacacs-server
+#---------------------------------------------------------
+#TACACS Global Configuration
+#---------------------------------------------------------
+#source-interface  : Ethernet12
+#timeout           : 10
+#auth-type         : pap
+#key configured    : Yes
+#--------------------------------------------------------------------------------------
+#HOST                 AUTH-TYPE    KEY-CONFIG PORT       PRIORITY   TIMEOUT    VRF
+#--------------------------------------------------------------------------------------
+#1.2.3.4              mschap       Yes        49         1          5          default

--- a/models/enterprise_sonic/tacacs_server/sonic_tacacs_server.yaml
+++ b/models/enterprise_sonic/tacacs_server/sonic_tacacs_server.yaml
@@ -44,6 +44,7 @@ DOCUMENTATION: |
           description:
             - Specifies the timeout of the tacacs server.
           type: int
+          default: 5
         source_interface:
           description:
             - Specifies the source interface of the tacacs server.
@@ -103,8 +104,10 @@ DOCUMENTATION: |
         - In case of merged, the input mode configuration will be merged with the existing tacacs server configuration on the device.
         - In case of deleted the existing tacacs server mode configuration will be removed from the device.
       default: merged
-      choices: ['merged', 'deleted']
+      choices: ['merged', 'replaced', 'overridden', 'deleted']
 EXAMPLES:
   - deleted_example_01.txt
   - deleted_example_02.txt
   - merged_example_01.txt
+  - replaced_example_01.txt
+  - overridden_example_01.txt


### PR DESCRIPTION
This is to add "replaced" and "overridden"states support for sonic_tacacs_server resource model.