### PR TITLE
Add replaced and overridden supports for RADIUS server resource model

### DIFF
--- a/models/enterprise_sonic/radius_server/overridden_example_01.txt
+++ b/models/enterprise_sonic/radius_server/overridden_example_01.txt
@@ -1,0 +1,53 @@
+# Using overridden
+#
+# Before state:
+# -------------
+#
+#sonic(config)# do show radius-server
+#---------------------------------------------------------
+#RADIUS Global Configuration
+#---------------------------------------------------------
+#timeout           : 10
+#auth-type         : pap
+#key configured    : Yes
+#--------------------------------------------------------------------------------------
+#HOST        AUTH-TYPE KEY-CONFIG AUTH-PORT PRIORITY TIMEOUT RTSMT VRF     SI
+#--------------------------------------------------------------------------------------
+#1.2.3.4     pap       No         49        1         5      -     -       Ethernet0
+#11.12.13.14 chap      Yes        49        10        5      3     -       -
+#
+- name: Overridden radius configurations
+  sonic_radius_server:
+    config:
+      auth_type: mschapv2
+      key: mschapv2
+      timeout: 20
+      servers:
+        - host:
+            name: 1.2.3.4
+            auth_type: mschapv2
+            key: mschapv2
+            source_interface: Ethernet12
+        - host:
+            name: 10.10.11.12
+            auth_type: chap
+            timeout: 30
+            priority: 2
+            port: 49
+    state: overridden
+#
+# After state:
+# ------------
+#
+#sonic(config)# do show radius-server
+#---------------------------------------------------------
+#RADIUS Global Configuration
+#---------------------------------------------------------
+#timeout           : 20
+#auth-type         : mschapv2
+#key configured    : Yes
+#--------------------------------------------------------------------------------------
+#HOST        AUTH-TYPE KEY-CONFIG AUTH-PORT PRIORITY TIMEOUT RTSMT VRF     SI
+#--------------------------------------------------------------------------------------
+#1.2.3.4      mschapv2 Yes        1812       -          -    -     -       Ethernet12
+#10.10.11.12  chap     No         49         2          30   -     -       -

--- a/models/enterprise_sonic/radius_server/replaced_example_01.txt
+++ b/models/enterprise_sonic/radius_server/replaced_example_01.txt
@@ -1,0 +1,44 @@
+# Using replaced
+#
+# Before state:
+# -------------
+#
+#sonic(config)# do show radius-server
+#---------------------------------------------------------
+#RADIUS Global Configuration
+#---------------------------------------------------------
+#timeout           : 10
+#auth-type         : pap
+#key configured    : Yes
+#--------------------------------------------------------------------------------------
+#HOST        AUTH-TYPE KEY-CONFIG AUTH-PORT PRIORITY TIMEOUT RTSMT VRF     SI
+#--------------------------------------------------------------------------------------
+#1.2.3.4     pap       No         49        1         5      -     -       Ethernet0
+#
+- name: Replace radius configurations
+  sonic_radius_server:
+    config:
+      auth_type: mschapv2
+      timeout: 20
+      servers:
+        - host:
+            name: 1.2.3.4
+            auth_type: mschapv2
+            key: mschapv2
+            source_interface: Ethernet12
+    state: replaced
+#
+# After state:
+# ------------
+#
+#sonic(config)# do show radius-server
+#---------------------------------------------------------
+#RADIUS Global Configuration
+#---------------------------------------------------------
+#timeout           : 20
+#auth-type         : mschapv2
+#key configured    : No
+#--------------------------------------------------------------------------------------
+#HOST        AUTH-TYPE KEY-CONFIG AUTH-PORT PRIORITY TIMEOUT RTSMT VRF     SI
+#--------------------------------------------------------------------------------------
+#1.2.3.4      mschapv2 Yes        1812       -          -    -     -       Ethernet12

--- a/models/enterprise_sonic/radius_server/sonic_radius_server.yaml
+++ b/models/enterprise_sonic/radius_server/sonic_radius_server.yaml
@@ -51,6 +51,7 @@ DOCUMENTATION: |
           description:
             - Specifies the timeout of the radius server.
           type: int
+          default: 5
         retransmit:
           description:
             - Specifies the re-transmit value of the radius server.
@@ -90,6 +91,7 @@ DOCUMENTATION: |
                   description:
                     - Specifies the port of the radius server host.
                   type: int
+                  default: 1812
                 timeout:
                   description:
                     - Specifies the timeout of the radius server host.
@@ -112,8 +114,10 @@ DOCUMENTATION: |
         - In case of merged, the input mode configuration will be merged with the existing radius server configuration on the device.
         - In case of deleted the existing radius server mode configuration will be removed from the device.
       default: merged
-      choices: ['merged', 'deleted']
+      choices: ['merged', 'replaced', 'overridden', 'deleted']
 EXAMPLES:
   - deleted_example_01.txt
   - deleted_example_02.txt
   - merged_example_01.txt
+  - replaced_example_01.txt
+  - overridden_example_01.txt


### PR DESCRIPTION
This is to add "replaced" and "overridden" states support for sonic_radius_server resource model.