### PR TITLE
SONiC DHCP Snooping model definition (2nd PR)

### DIFF
--- a/models/enterprise_sonic/dhcp_snooping/deleted_example_01.txt
+++ b/models/enterprise_sonic/dhcp_snooping/deleted_example_01.txt
@@ -1,0 +1,33 @@
+# Using deleted
+#
+# Before State:
+# -------------
+#
+# sonic# show ip dhcp snooping
+# !
+# DHCP snooping is Enabled
+# DHCP snooping source MAC verification is Enabled
+# DHCP snooping is enabled on the following VLANs: 1 2 3 5 
+# DHCP snooping trusted interfaces: Ethernet8 
+# !
+
+- name: Disable DHCPv4 snooping on some VLANs
+  dellemc.enterprise_sonic.sonic_dhcp_snooping:
+    config:
+      afis:
+        - afi: ipv4
+          vlans:
+            - 3
+            - 5
+    state: deleted
+
+# After State:
+# ------------
+#
+# sonic# show ip dhcp snooping
+# !
+# DHCP snooping is Enabled
+# DHCP snooping source MAC verification is Enabled
+# DHCP snooping is enabled on the following VLANs: 1 2
+# DHCP snooping trusted interfaces: 
+# !

--- a/models/enterprise_sonic/dhcp_snooping/deleted_example_02.txt
+++ b/models/enterprise_sonic/dhcp_snooping/deleted_example_02.txt
@@ -24,7 +24,7 @@
 #
 # sonic# show ipv6 dhcp snooping
 # !
-# DHCPv6 snooping is Disabled
+# DHCPv6 snooping is Enabled
 # DHCPv6 snooping source MAC verification is Disabled
 # DHCPv6 snooping is enabled on the following VLANs: 
 # DHCPv6 snooping trusted interfaces: PortChannel1 PortChannel2 PortChannel3 PortChannel4

--- a/models/enterprise_sonic/dhcp_snooping/deleted_example_02.txt
+++ b/models/enterprise_sonic/dhcp_snooping/deleted_example_02.txt
@@ -1,0 +1,31 @@
+# Using deleted
+#
+# Before State:
+# -------------
+#
+# sonic# show ipv6 dhcp snooping
+# !
+# DHCPv6 snooping is Enabled
+# DHCPv6 snooping source MAC verification is Disabled
+# DHCPv6 snooping is enabled on the following VLANs: 4 
+# DHCPv6 snooping trusted interfaces: PortChannel1 PortChannel2 PortChannel3 PortChannel4
+# !
+
+- name: Disable DHCPv6 snooping on all VLANs
+  dellemc.enterprise_sonic.sonic_dhcp_snooping:
+    config:
+      afis:
+        - afi: ipv6
+          vlans:
+    state: deleted
+
+# After State:
+# ------------
+#
+# sonic# show ipv6 dhcp snooping
+# !
+# DHCPv6 snooping is Disabled
+# DHCPv6 snooping source MAC verification is Disabled
+# DHCPv6 snooping is enabled on the following VLANs: 
+# DHCPv6 snooping trusted interfaces: PortChannel1 PortChannel2 PortChannel3 PortChannel4
+# !

--- a/models/enterprise_sonic/dhcp_snooping/deleted_example_03.txt
+++ b/models/enterprise_sonic/dhcp_snooping/deleted_example_03.txt
@@ -1,0 +1,30 @@
+# Using deleted
+#
+# Before State:
+# -------------
+#
+# sonic# show ipv6 dhcp snooping
+# !
+# DHCPv6 snooping is Enabled
+# DHCPv6 snooping source MAC verification is Disabled
+# DHCPv6 snooping is enabled on the following VLANs: 4 
+# DHCPv6 snooping trusted interfaces: PortChannel1 PortChannel2 PortChannel3 PortChannel4
+# !
+
+- name: Delete all DHCPv6 configuration
+  dellemc.enterprise_sonic.sonic_dhcp_snooping:
+    config:
+      afis:
+        - afi: ipv6
+    state: deleted
+
+# After State:
+# ------------
+#
+# sonic# show ipv6 dhcp snooping
+# !
+# DHCPv6 snooping is Disabled
+# DHCPv6 snooping source MAC verification is Disabled
+# DHCPv6 snooping is enabled on the following VLANs:
+# DHCPv6 snooping trusted interfaces:
+# !

--- a/models/enterprise_sonic/dhcp_snooping/deleted_example_04.txt
+++ b/models/enterprise_sonic/dhcp_snooping/deleted_example_04.txt
@@ -1,0 +1,40 @@
+# Using deleted
+#
+# Before State:
+# -------------
+#
+# sonic# show ip dhcp snooping binding
+# !
+# Total number of Dynamic bindings: 0
+# Total number of Static bindings: 2
+# Total number of Tentative bindings: 0
+# MAC Address        IP Address       VLAN   Interface    Type     Lease (Secs)
+# -----------------  ---------------  ----   -----------  -------  -----------
+# 00:b0:d0:63:c2:26  192.0.2.146      1      Ethernet4    static   NA         
+# aa:f7:67:fc:f4:9a  156.33.90.167    2      PortChannel1  static   NA   
+# !
+
+- name: Delete a DHCPv4 snooping binding
+  dellemc.enterprise_sonic.sonic_dhcp_snooping:
+    config:
+      afis:
+        - afi: ipv4
+          source_bindings:
+            - mac_addr: 00:b0:d0:63:c2:26
+              ip_addr: 192.0.2.146
+              intf_name: Ethernet4
+              vlan_id: 1
+    state: deleted
+
+# After State:
+# ------------
+#
+# sonic# show ip dhcp snooping binding
+# !
+# Total number of Dynamic bindings: 0
+# Total number of Static bindings: 2
+# Total number of Tentative bindings: 0
+# MAC Address        IP Address       VLAN   Interface    Type     Lease (Secs)
+# -----------------  ---------------  ----   -----------  -------  -----------     
+# aa:f7:67:fc:f4:9a  156.33.90.167    2      PortChannel1  static   NA         
+# !

--- a/models/enterprise_sonic/dhcp_snooping/dhcp_snooping.yaml
+++ b/models/enterprise_sonic/dhcp_snooping/dhcp_snooping.yaml
@@ -8,119 +8,112 @@ author: Simon Nathans (@simon-nathans)
 options:
   config:
     description: The DHCP snooping configuration.
-    type: list
-    elements: dict
+    type: dict
     suboptions:
-      global:
+      ipv4:
         description:
-          - Configure DHCP snooping on the global level.
-        type: list
-        elements: dict
+          - Configure DHCPv4 snooping.
+        type: dict
         suboptions:
-          ipv4:
+          enabled:
             description:
-              - Configure DHCPv4 snooping.
-            type: dict
+              - Enable or disable DHCPv4 snooping globally.
+            type: bool
+          vlans:
+            description:
+              - Configure DHCPv4 snooping on a VLAN or range of VLANs.
+            type: list
+            elements: dict
             suboptions:
+              vlan_id:
+                description:
+                  - VLAN ID or range of VLAN IDs.
+                type: str
+                required: true
               enabled:
                 description:
-                  - Enable or disable DHCPv4 snooping globally.
+                  - Enable or disable DHCPv4 snooping on a VLAN or range of VLANs.
                 type: bool
-              vlans:
-                description:
-                  - Configure DHCPv4 snooping on a VLAN or range of VLANs.
-                type: list
-                elements: dict
-                suboptions:
-                  name:
-                    description:
-                      - VLAN ID or range of VLAN IDs.
-                    type: str
-                    required: true
-                  enabled:
-                    description:
-                      - Enable or disable DHCPv4 snooping on a VLAN or range of VLANs.
-                    type: bool
-              verify_mac:
-                description:
-                  - Enable or disable DHCPv4 snooping MAC verification.
-                type: bool
-              source_binding:
-                description:
-                  - Configure DHCPv4 snooping binding entries.
-                type: list
-                elements: dict
-                suboptions:
-                  interface_name:
-                    description:
-                      - Create an entry in the DHCPv4 snooping binding database.
-                      - Can be either an Ethernet or PortChannel interface.
-                    type: str
-                    required: true
-                  ip_address:
-                    description:
-                      - The IP address for the binding.
-                    type: str
-                  mac_address:
-                    description:
-                      - The MAC address for the binding.
-                    type: str
-                  vlan:
-                    description:
-                      - The VLAN ID for the binding.
-                    type: int
-          ipv6:
+          verify_mac:
             description:
-              - Configure DHCPv6 snooping.
-            type: dict
+              - Enable or disable DHCPv4 snooping MAC verification.
+            type: bool
+          source_binding:
+            description:
+              - Configure DHCPv4 snooping binding entries.
+            type: list
+            elements: dict
             suboptions:
+              interface_name:
+                description:
+                  - Create an entry in the DHCPv4 snooping binding database.
+                  - Can be either an Ethernet or PortChannel interface.
+                type: str
+                required: true
+              ip_address:
+                description:
+                  - The IP address for the binding.
+                type: str
+              mac_address:
+                description:
+                  - The MAC address for the binding.
+                type: str
+              vlan:
+                description:
+                  - The VLAN ID for the binding.
+                type: int
+      ipv6:
+        description:
+          - Configure DHCPv6 snooping.
+        type: dict
+        suboptions:
+          enabled:
+            description:
+              - Enable or disable DHCPv6 snooping globally.
+            type: bool
+          vlans:
+            description:
+              - Configure DHCPv6 snooping on a VLAN or range of VLANs.
+            type: list
+            elements: dict
+            suboptions:
+              vlan_id:
+                description:
+                  - VLAN ID or range of VLAN IDs.
+                type: str
+                required: true
               enabled:
                 description:
-                  - Enable or disable DHCPv6 snooping globally.
+                  - Enable or disable DHCPv6 snooping on a VLAN or range of VLANs.
                 type: bool
-              vlans:
+          verify_mac:
+            description:
+              - Enable or disable DHCPv6 snooping MAC verification.
+            type: bool
+          source_binding:
+            description:
+              - Configure DHCPv6 snooping binding entries.
+            type: list
+            elements: dict
+            suboptions:
+              interface_name:
                 description:
-                  - Configure DHCPv6 snooping on a VLAN or range of VLANs.
-                type: list
-                elements: dict
-                suboptions:
-                  name:
-                    description:
-                      - VLAN ID or range of VLAN IDs.
-                    type: str
-                    required: true
-                  enabled:
-                    description:
-                      - Enable or disable DHCPv6 snooping on a VLAN or range of VLANs.
-                    type: bool
-              verify_mac:
+                  - Create an entry in the DHCPv6 snooping binding database.
+                  - Can be either an Ethernet or PortChannel interface.
+                type: str
+                required: true
+              ip_address:
                 description:
-                  - Enable or disable DHCPv6 snooping MAC verification.
-                type: bool
-              source_binding:
+                  - The IP address for the binding.
+                type: str
+              mac_address:
                 description:
-                  - Configure DHCPv6 snooping binding entries.
-                type: list
-                elements: dict
-                suboptions:
-                  interface_name:
-                    description:
-                      - Create an entry in the DHCPv6 snooping binding database.
-                      - Can be either an Ethernet or PortChannel interface.
-                    type: str
-                    required: true
-                  ip_address:
-                    description:
-                      - The IP address for the binding.
-                    type: str
-                  mac_address:
-                    description:
-                      - The MAC address for the binding.
-                    type: str
-                  vlan:
-                    description:
-                      - The VLAN ID for the binding.
-                    type: int
+                  - The MAC address for the binding.
+                type: str
+              vlan:
+                description:
+                  - The VLAN ID for the binding.
+                type: int
       interfaces:
         description:
           - Configure DHCP snooping on the interface level.

--- a/models/enterprise_sonic/dhcp_snooping/dhcp_snooping.yaml
+++ b/models/enterprise_sonic/dhcp_snooping/dhcp_snooping.yaml
@@ -51,23 +51,24 @@ options:
                 type: list
                 elements: dict
                 suboptions:
+                  interface_name:
+                    description:
+                      - Create an entry in the DHCPv4 snooping binding database.
+                      - Can be either an Ethernet or PortChannel interface.
+                    type: str
+                    required: true
                   ip_address:
                     description:
-                      - Create a static DHCPv4 snooping binding entry for an IP address.
+                      - The IP address for the binding.
                     type: str
                   mac_address:
                     description:
-                      - Create a static DHCPv4 snooping binding entry for a MAC address.
+                      - The MAC address for the binding.
                     type: str
                   vlan:
                     description:
-                      - Create a static DHCPv4 snooping binding entry for a VLAN ID.
+                      - The VLAN ID for the binding.
                     type: int
-                  interface_name:
-                    description:
-                      - Create a static DHCPv4 snooping binding entry for a physical interface name.
-                      - Can be either an Ethernet or PortChannel interface.
-                    type: str
           ipv6:
             description:
               - Configure DHCPv6 snooping.
@@ -102,32 +103,40 @@ options:
                 type: list
                 elements: dict
                 suboptions:
+                  interface_name:
+                    description:
+                      - Create an entry in the DHCPv6 snooping binding database.
+                      - Can be either an Ethernet or PortChannel interface.
+                    type: str
+                    required: true
                   ip_address:
                     description:
-                      - Create a static DHCPv6 snooping binding entry for an IP address.
+                      - The IP address for the binding.
                     type: str
                   mac_address:
                     description:
-                      - Create a static DHCPv6 snooping binding entry for a MAC address.
+                      - The MAC address for the binding.
                     type: str
                   vlan:
                     description:
-                      - Create a static DHCPv6 snooping binding entry for a VLAN ID.
+                      - The VLAN ID for the binding.
                     type: int
-                  interface_name:
-                    description:
-                      - Create a static DHCPv6 snooping binding entry for a physical interface name.
-                      - Can be either an Ethernet or PortChannel interface.
-                    type: str
       interfaces:
         description:
           - Configure DHCP snooping on the interface level.
         type: list
         elements: dict
         suboptions:
-          names:
+          intf_type:
             description:
-              - Name of the interface or range of interfaces.
+              - The type of interface. Can be Ethernet or PortChannel.
+            type: str
+            choices: [Ethernet, PortChannel]
+            required: true
+          intf_number:
+            description:
+              - Interface number.
+              - If Ethernet, must be single number; if PortChannel, can be range.
             type: str
             required: true
           ipv4:

--- a/models/enterprise_sonic/dhcp_snooping/dhcp_snooping.yaml
+++ b/models/enterprise_sonic/dhcp_snooping/dhcp_snooping.yaml
@@ -1,5 +1,12 @@
 ---
 GENERATOR_VERSION: "1.0"
+ANSIBLE_METADATA: |
+  {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+    'license': 'Apache 2.0'
+  }
 NETWORK_OS: sonic
 RESOURCE: dhcp_snooping
 COPYRIGHT: Copyright 2023 Dell Inc. or its subsidiaries. All Rights Reserved

--- a/models/enterprise_sonic/dhcp_snooping/dhcp_snooping.yaml
+++ b/models/enterprise_sonic/dhcp_snooping/dhcp_snooping.yaml
@@ -105,5 +105,6 @@ EXAMPLES:
   - deleted_example_01.txt
   - deleted_example_02.txt
   - deleted_example_03.txt
+  - deleted_example_04.txt
   - overridden_example_01.txt
   - replaced_example_01.txt

--- a/models/enterprise_sonic/dhcp_snooping/dhcp_snooping.yaml
+++ b/models/enterprise_sonic/dhcp_snooping/dhcp_snooping.yaml
@@ -1,15 +1,8 @@
 ---
 GENERATOR_VERSION: "1.0"
-ANSIBLE_METADATA: |
-  {
-    'metadata_version': '1.1',
-    'status': ['preview'],
-    'supported_by': 'community',
-    'license': 'Apache 2.0'
-  }
 NETWORK_OS: sonic
 RESOURCE: dhcp_snooping
-COPYRIGHT: Copyright 2022 Dell Inc. or its subsidiaries. All Rights Reserved
+COPYRIGHT: Copyright 2023 Dell Inc. or its subsidiaries. All Rights Reserved
 DOCUMENTATION: |
   module: sonic_dhcp_snooping
   version_added: 1.0.0
@@ -26,7 +19,7 @@ DOCUMENTATION: |
         afis:
           description:
             - List of address families to configure.
-            - There can be up to two items in this list: one where afi==ipv4 and one where afi==ipv6 to configure DHCPv4 and DHCPv6, respectively.
+            - "There can be up to two items in this list: one where afi==ipv4 and one where afi==ipv6 to configure DHCPv4 and DHCPv6, respectively."
           type: list
           elements: dict
           suboptions:
@@ -37,6 +30,10 @@ DOCUMENTATION: |
               type: str
               choices: ['ipv4', 'ipv6']
               required: true
+            enabled:
+              description:
+                - Enable or disable DHCP snooping on the AFI.
+              type: bool
             vlans:
               description:
                 - Enable or disable DHCP snooping on a VLAN or range of VLANs.

--- a/models/enterprise_sonic/dhcp_snooping/dhcp_snooping.yaml
+++ b/models/enterprise_sonic/dhcp_snooping/dhcp_snooping.yaml
@@ -1,0 +1,176 @@
+module: sonic_dhcp_snooping
+version_added: 1.0.0
+notes:
+  - "Tested against Enterprise SONiC Distribution by Dell Technologies."
+short_description: "Manage DHCP Snooping on SONiC"
+description: "This module provides configuration management of DHCP snooping for devices running SONiC."
+author: Simon Nathans (@simon-nathans)
+options:
+  config:
+    description: The DHCP snooping configuration.
+    type: list
+    elements: dict
+    suboptions:
+      global:
+        description:
+          - Configure DHCP snooping on the global level.
+        type: list
+        elements: dict
+        suboptions:
+          ipv4:
+            description:
+              - Configure DHCPv4 snooping.
+            type: dict
+            suboptions:
+              enabled:
+                description:
+                  - Enable or disable DHCPv4 snooping globally.
+                type: bool
+              vlans:
+                description:
+                  - Configure DHCPv4 snooping on a VLAN or range of VLANs.
+                type: list
+                elements: dict
+                suboptions:
+                  name:
+                    description:
+                      - VLAN ID or range of VLAN IDs.
+                    type: str
+                    required: true
+                  enabled:
+                    description:
+                      - Enable or disable DHCPv4 snooping on a VLAN or range of VLANs.
+                    type: bool
+              verify:
+                description:
+                  - Configure DHCPv4 snooping verification.
+                type: list
+                elements: dict
+                suboptions:
+                  mac_address:
+                    description:
+                      - Enable or disable DHCPv4 snooping MAC verification.
+                    type: bool
+              source_binding:
+                description:
+                  - Configure DHCPv4 snooping binding entries.
+                type: list
+                elements: dict
+                suboptions:
+                  ip_address:
+                    description:
+                      - Create a static DHCPv4 snooping binding entry for an IP address.
+                    type: str
+                  mac_address:
+                    description:
+                      - Create a static DHCPv4 snooping binding entry for a MAC address.
+                    type: str
+                  vlan:
+                    description:
+                      - Create a static DHCPv4 snooping binding entry for a VLAN ID.
+                    type: int
+                  interface_name:
+                    description:
+                      - Create a static DHCPv4 snooping binding entry for a physical interface name.
+                      - Can be either an Ethernet or PortChannel interface.
+                    type: str
+          ipv6:
+            description:
+              - Configure DHCPv6 snooping.
+            type: dict
+            suboptions:
+              enabled:
+                description:
+                  - Enable or disable DHCPv6 snooping globally.
+                type: bool
+              vlans:
+                description:
+                  - Configure DHCPv6 snooping on a VLAN or range of VLANs.
+                type: list
+                elements: dict
+                suboptions:
+                  name:
+                    description:
+                      - VLAN ID or range of VLAN IDs.
+                    type: str
+                    required: true
+                  enabled:
+                    description:
+                      - Enable or disable DHCPv6 snooping on a VLAN or range of VLANs.
+                    type: bool
+              verify:
+                description:
+                  - Configure DHCPv6 snooping verification.
+                type: list
+                elements: dict
+                suboptions:
+                  mac_address:
+                    description:
+                      - Enable or disable DHCPv6 snooping MAC verification.
+                    type: bool
+              source_binding:
+                description:
+                  - Configure DHCPv6 snooping binding entries.
+                type: list
+                elements: dict
+                suboptions:
+                  ip_address:
+                    description:
+                      - Create a static DHCPv6 snooping binding entry for an IP address.
+                    type: str
+                  mac_address:
+                    description:
+                      - Create a static DHCPv6 snooping binding entry for a MAC address.
+                    type: str
+                  vlan:
+                    description:
+                      - Create a static DHCPv6 snooping binding entry for a VLAN ID.
+                    type: int
+                  interface_name:
+                    description:
+                      - Create a static DHCPv6 snooping binding entry for a physical interface name.
+                      - Can be either an Ethernet or PortChannel interface.
+                    type: str
+      interfaces:
+        description:
+          - Configure DHCP snooping on the interface level.
+        type: list
+        elements: dict
+        suboptions:
+          names:
+            description:
+              - Name of the interface or range of interfaces.
+            type: str
+            required: true
+          ipv4:
+            description:
+              - Configure DHCPv4 snooping for the interface(s).
+            type: dict
+            suboptions:
+              enabled:
+                description:
+                  - Enable or disable DHCPv4 snooping for the interface(s).
+                type: bool
+              trust:
+                description:
+                  - Mark Trust mode for DHCPv4 snooping on the interface(s).
+                type: bool
+          ipv6:
+            description:
+              - Configure DHCPv6 snooping for the interface(s).
+            type: dict
+            suboptions:
+              enabled:
+                description:
+                  - Enable or disable DHCPv6 snooping for the interface(s).
+                type: bool
+              trust:
+                description:
+                  - Mark Trust mode for DHCPv6 snooping on the interface(s).
+                type: bool
+  state:
+    description:
+      - The state of the configuration after module completion.
+    default: merged
+    choices: ["merged", "deleted", "overridden", "replaced"]
+    type: str

--- a/models/enterprise_sonic/dhcp_snooping/dhcp_snooping.yaml
+++ b/models/enterprise_sonic/dhcp_snooping/dhcp_snooping.yaml
@@ -1,166 +1,109 @@
-module: sonic_dhcp_snooping
-version_added: 1.0.0
-notes:
-  - "Tested against Enterprise SONiC Distribution by Dell Technologies."
-short_description: "Manage DHCP Snooping on SONiC"
-description: "This module provides configuration management of DHCP snooping for devices running SONiC."
-author: Simon Nathans (@simon-nathans)
-options:
-  config:
-    description: The DHCP snooping configuration.
-    type: dict
-    suboptions:
-      ipv4:
-        description:
-          - Configure DHCPv4 snooping.
-        type: dict
-        suboptions:
-          enabled:
-            description:
-              - Enable or disable DHCPv4 snooping globally.
-            type: bool
-          vlans:
-            description:
-              - Configure DHCPv4 snooping on a VLAN or range of VLANs.
-            type: list
-            elements: dict
-            suboptions:
-              vlan_id:
-                description:
-                  - VLAN ID or range of VLAN IDs.
-                type: str
-                required: true
-              enabled:
-                description:
-                  - Enable or disable DHCPv4 snooping on a VLAN or range of VLANs.
-                type: bool
-          verify_mac:
-            description:
-              - Enable or disable DHCPv4 snooping MAC verification.
-            type: bool
-          source_binding:
-            description:
-              - Configure DHCPv4 snooping binding entries.
-            type: list
-            elements: dict
-            suboptions:
-              interface_name:
-                description:
-                  - Create an entry in the DHCPv4 snooping binding database.
-                  - Can be either an Ethernet or PortChannel interface.
-                type: str
-                required: true
-              ip_address:
-                description:
-                  - The IP address for the binding.
-                type: str
-              mac_address:
-                description:
-                  - The MAC address for the binding.
-                type: str
-              vlan:
-                description:
-                  - The VLAN ID for the binding.
-                type: int
-      ipv6:
-        description:
-          - Configure DHCPv6 snooping.
-        type: dict
-        suboptions:
-          enabled:
-            description:
-              - Enable or disable DHCPv6 snooping globally.
-            type: bool
-          vlans:
-            description:
-              - Configure DHCPv6 snooping on a VLAN or range of VLANs.
-            type: list
-            elements: dict
-            suboptions:
-              vlan_id:
-                description:
-                  - VLAN ID or range of VLAN IDs.
-                type: str
-                required: true
-              enabled:
-                description:
-                  - Enable or disable DHCPv6 snooping on a VLAN or range of VLANs.
-                type: bool
-          verify_mac:
-            description:
-              - Enable or disable DHCPv6 snooping MAC verification.
-            type: bool
-          source_binding:
-            description:
-              - Configure DHCPv6 snooping binding entries.
-            type: list
-            elements: dict
-            suboptions:
-              interface_name:
-                description:
-                  - Create an entry in the DHCPv6 snooping binding database.
-                  - Can be either an Ethernet or PortChannel interface.
-                type: str
-                required: true
-              ip_address:
-                description:
-                  - The IP address for the binding.
-                type: str
-              mac_address:
-                description:
-                  - The MAC address for the binding.
-                type: str
-              vlan:
-                description:
-                  - The VLAN ID for the binding.
-                type: int
-      interfaces:
-        description:
-          - Configure DHCP snooping on the interface level.
-        type: list
-        elements: dict
-        suboptions:
-          intf_type:
-            description:
-              - The type of interface. Can be Ethernet or PortChannel.
-            type: str
-            choices: [Ethernet, PortChannel]
-            required: true
-          intf_number:
-            description:
-              - Interface number.
-              - If Ethernet, must be single number; if PortChannel, can be range.
-            type: str
-            required: true
-          ipv4:
-            description:
-              - Configure DHCPv4 snooping for the interface(s).
-            type: dict
-            suboptions:
-              enabled:
-                description:
-                  - Enable or disable DHCPv4 snooping for the interface(s).
-                type: bool
-              trust:
-                description:
-                  - Mark Trust mode for DHCPv4 snooping on the interface(s).
-                type: bool
-          ipv6:
-            description:
-              - Configure DHCPv6 snooping for the interface(s).
-            type: dict
-            suboptions:
-              enabled:
-                description:
-                  - Enable or disable DHCPv6 snooping for the interface(s).
-                type: bool
-              trust:
-                description:
-                  - Mark Trust mode for DHCPv6 snooping on the interface(s).
-                type: bool
-  state:
-    description:
-      - The state of the configuration after module completion.
-    default: merged
-    choices: ["merged", "deleted", "overridden", "replaced"]
-    type: str
+---
+GENERATOR_VERSION: "1.0"
+ANSIBLE_METADATA: |
+  {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+    'license': 'Apache 2.0'
+  }
+NETWORK_OS: sonic
+RESOURCE: dhcp_snooping
+COPYRIGHT: Copyright 2022 Dell Inc. or its subsidiaries. All Rights Reserved
+DOCUMENTATION: |
+  module: sonic_dhcp_snooping
+  version_added: 1.0.0
+  notes:
+    - "Tested against Enterprise SONiC Distribution by Dell Technologies."
+  short_description: "Manage DHCP Snooping on SONiC"
+  description: "This module provides configuration management of DHCP snooping for devices running SONiC."
+  author: Simon Nathans (@simon-nathans)
+  options:
+    config:
+      description: The DHCP snooping configuration.
+      type: dict
+      suboptions:
+        afis:
+          description:
+            - List of address families to configure.
+            - There can be up to two items in this list: one where afi==ipv4 and one where afi==ipv6 to configure DHCPv4 and DHCPv6, respectively.
+          type: list
+          elements: dict
+          suboptions:
+            afi:
+              description:
+                - The address family to configure.
+                - Can be either ipv4 or ipv6.
+              type: str
+              choices: ['ipv4', 'ipv6']
+              required: true
+            vlans:
+              description:
+                - Enable or disable DHCP snooping on a VLAN or range of VLANs.
+                - Give a single VLAN ID or hyphen-delimited range of VLAN IDs, e.g., "1" or "1-3".
+              type: list
+              elements: str
+            verify_mac:
+              description:
+                - Enable or disable DHCP snooping MAC verification.
+              type: bool
+            trusted:
+              description:
+                - Mark interfaces as trusted for DHCP snooping.
+              type: list
+              elements: dict
+              suboptions:
+                intf_number:
+                  description:
+                    - The interface number.
+                    - If the interface type is Ethernet, must be a single number; if the type is PortChannel, can be a single number or a hyphen-delimited range.
+                  type: str
+                  required: true
+                intf_type:
+                  description:
+                    - The type of interface.
+                    - Can be Ethernet or PortChannel.
+                  type: str
+                  choices: ['Ethernet', 'PortChannel']
+            source_bindings:
+              description:
+                - Create a static entry in the DHCP snooping binding database.
+              type: list
+              elements: dict
+              suboptions:
+                mac_addr:
+                  description:
+                    - The binding's MAC address.
+                  type: str
+                  required: true
+                ip_addr:
+                  description:
+                    - The bindings's IP address.
+                  type: str
+                  required: true
+                intf_name:
+                  description:
+                    - The binding's interface name.
+                    - Can be an Ethernet or a PortChannel interface.
+                  type: str
+                  required: true
+                vlan_id:
+                  description:
+                    - The binding's VLAN ID.
+                  type: int
+                  required: true
+    state:
+      description:
+        - The state of the configuration after module completion.
+      default: merged
+      choices: ['merged', 'deleted', 'overridden', 'replaced']
+      type: str
+EXAMPLES:
+  - merged_example_01.txt
+  - merged_example_02.txt
+  - merged_example_03.txt
+  - deleted_example_01.txt
+  - deleted_example_02.txt
+  - deleted_example_03.txt
+  - overridden_example_01.txt
+  - replaced_example_01.txt

--- a/models/enterprise_sonic/dhcp_snooping/dhcp_snooping.yaml
+++ b/models/enterprise_sonic/dhcp_snooping/dhcp_snooping.yaml
@@ -41,16 +41,10 @@ options:
                     description:
                       - Enable or disable DHCPv4 snooping on a VLAN or range of VLANs.
                     type: bool
-              verify:
+              verify_mac:
                 description:
-                  - Configure DHCPv4 snooping verification.
-                type: list
-                elements: dict
-                suboptions:
-                  mac_address:
-                    description:
-                      - Enable or disable DHCPv4 snooping MAC verification.
-                    type: bool
+                  - Enable or disable DHCPv4 snooping MAC verification.
+                type: bool
               source_binding:
                 description:
                   - Configure DHCPv4 snooping binding entries.
@@ -98,16 +92,10 @@ options:
                     description:
                       - Enable or disable DHCPv6 snooping on a VLAN or range of VLANs.
                     type: bool
-              verify:
+              verify_mac:
                 description:
-                  - Configure DHCPv6 snooping verification.
-                type: list
-                elements: dict
-                suboptions:
-                  mac_address:
-                    description:
-                      - Enable or disable DHCPv6 snooping MAC verification.
-                    type: bool
+                  - Enable or disable DHCPv6 snooping MAC verification.
+                type: bool
               source_binding:
                 description:
                   - Configure DHCPv6 snooping binding entries.

--- a/models/enterprise_sonic/dhcp_snooping/merged_example_01.txt
+++ b/models/enterprise_sonic/dhcp_snooping/merged_example_01.txt
@@ -16,6 +16,7 @@
     config:
       afis:
         - afi: ipv4
+          enabled: true
           vlans:
             - 1-3
             - 5

--- a/models/enterprise_sonic/dhcp_snooping/merged_example_01.txt
+++ b/models/enterprise_sonic/dhcp_snooping/merged_example_01.txt
@@ -1,0 +1,37 @@
+# Using merged
+#
+# Before State:
+# -------------
+#
+# sonic# show ip dhcp snooping
+# !
+# DHCP snooping is Disabled
+# DHCP snooping source MAC verification is Disabled
+# DHCP snooping is enabled on the following VLANs: 
+# DHCP snooping trusted interfaces: 
+# !
+
+- name: Configure DHCPv4 snooping global settings
+  dellemc.enterprise_sonic.sonic_dhcp_snooping:
+    config:
+      afis:
+        - afi: ipv4
+          vlans:
+            - 1-3
+            - 5
+          verify_mac: true
+          trusted:
+            - intf_number: 8
+              intf_type: Ethernet
+    state: merged
+
+# After State:
+# ------------
+#
+# sonic# show ip dhcp snooping
+# !
+# DHCP snooping is Enabled
+# DHCP snooping source MAC verification is Enabled
+# DHCP snooping is enabled on the following VLANs: 1 2 3 5 
+# DHCP snooping trusted interfaces: Ethernet8 
+# !

--- a/models/enterprise_sonic/dhcp_snooping/merged_example_02.txt
+++ b/models/enterprise_sonic/dhcp_snooping/merged_example_02.txt
@@ -16,6 +16,7 @@
     config:
       afis:
         - afi: ipv6
+          enabled: true
           vlans:
             - 4
           trusted:

--- a/models/enterprise_sonic/dhcp_snooping/merged_example_02.txt
+++ b/models/enterprise_sonic/dhcp_snooping/merged_example_02.txt
@@ -1,0 +1,37 @@
+# Using merged
+#
+# Before State:
+# -------------
+#
+# sonic# show ipv6 dhcp snooping
+# !
+# DHCPv6 snooping is Disabled
+# DHCPv6 snooping source MAC verification is Disabled
+# DHCPv6 snooping is enabled on the following VLANs: 
+# DHCPv6 snooping trusted interfaces: 
+# !
+
+- name: Configure DHCPv6 snooping global settings
+  dellemc.enterprise_sonic.sonic_dhcp_snooping:
+    config:
+      afis:
+        - afi: ipv6
+          vlans:
+            - 4
+          trusted:
+            - intf_number: 2
+              intf_type: Ethernet
+            - intf_number: 1-4
+              intf_type: PortChannel
+    state: merged
+
+# After State:
+# ------------
+#
+# sonic# show ipv6 dhcp snooping
+# !
+# DHCPv6 snooping is Enabled
+# DHCPv6 snooping source MAC verification is Disabled
+# DHCPv6 snooping is enabled on the following VLANs: 4 
+# DHCPv6 snooping trusted interfaces: PortChannel1 PortChannel2 PortChannel3 PortChannel4
+# !

--- a/models/enterprise_sonic/dhcp_snooping/merged_example_03.txt
+++ b/models/enterprise_sonic/dhcp_snooping/merged_example_03.txt
@@ -1,0 +1,43 @@
+# Using merged
+#
+# Before State:
+# -------------
+#
+# sonic# show ip dhcp snooping binding
+# !
+# Total number of Dynamic bindings: 0
+# Total number of Static bindings: 0
+# Total number of Tentative bindings: 0
+# MAC Address        IP Address       VLAN   Interface    Type     Lease (Secs)
+# -----------------  ---------------  ----   -----------  -------  -----------
+# !
+
+- name: Add DHCPv4 snooping bindings
+  dellemc.enterprise_sonic.sonic_dhcp_snooping:
+    config:
+      afis:
+        - afi: ipv4
+          source_bindings:
+            - mac_addr: 00:b0:d0:63:c2:26
+              ip_addr: 192.0.2.146
+              intf_name: Ethernet4
+              vlan_id: 1
+            - mac_addr: aa:f7:67:fc:f4:9a
+              ip_addr: 156.33.90.167
+              intf_name: PortChannel1
+              vlan_id: 2
+    state: merged
+
+# After State:
+# ------------
+#
+# sonic# show ip dhcp snooping binding
+# !
+# Total number of Dynamic bindings: 0
+# Total number of Static bindings: 2
+# Total number of Tentative bindings: 0
+# MAC Address        IP Address       VLAN   Interface    Type     Lease (Secs)
+# -----------------  ---------------  ----   -----------  -------  -----------
+# 00:b0:d0:63:c2:26  192.0.2.146      1      Ethernet4    static   NA         
+# aa:f7:67:fc:f4:9a  156.33.90.167    2      PortChannel1  static   NA         
+# !

--- a/models/enterprise_sonic/dhcp_snooping/overriden_example_01.txt
+++ b/models/enterprise_sonic/dhcp_snooping/overriden_example_01.txt
@@ -1,0 +1,35 @@
+# Using replaced
+#
+# Before State:
+# -------------
+#
+# sonic# show ipv6 dhcp snooping binding
+# !
+# MAC Address        IP Address       VLAN   Interface    Type     Lease (Secs)
+# -----------------  ---------------  ----   -----------  -------  -----------
+# 00:b0:d0:63:c2:26  192.0.2.146      1      Ethernet4    static   NA         
+# 28:21:28:15:c1:1b  141.202.222.118  1      Ethernet2    static   NA         
+# aa:f7:67:fc:f4:9a  156.33.90.167    2      PortChannel1  static   NA         
+# !
+
+- name: Override DHCPv6 snooping bindings
+  dellemc.enterprise_sonic.sonic_dhcp_snooping:
+    config:
+      afis:
+        - afi: ipv6
+          source_bindings:
+            - mac_addr: 00:b0:d0:63:c2:26
+              ip_addr: 192.0.2.146
+              intf_name: Ethernet4
+              vlan_id: 3
+    state: replaced
+
+# After State:
+# ------------
+#
+# sonic# show ipv6 dhcp snooping binding
+# !
+# MAC Address        IP Address       VLAN   Interface    Type     Lease (Secs)
+# -----------------  ---------------  ----   -----------  -------  -----------
+# 00:b0:d0:63:c2:26  192.0.2.146      3      Ethernet4    static   NA     
+# !

--- a/models/enterprise_sonic/dhcp_snooping/overriden_example_01.txt
+++ b/models/enterprise_sonic/dhcp_snooping/overriden_example_01.txt
@@ -1,4 +1,4 @@
-# Using replaced
+# Using override
 #
 # Before State:
 # -------------
@@ -22,7 +22,7 @@
               ip_addr: 192.0.2.146
               intf_name: Ethernet4
               vlan_id: 3
-    state: replaced
+    state: overriden
 
 # After State:
 # ------------

--- a/models/enterprise_sonic/dhcp_snooping/replaced_example_01.txt
+++ b/models/enterprise_sonic/dhcp_snooping/replaced_example_01.txt
@@ -1,0 +1,37 @@
+# Using replaced
+#
+# Before State:
+# -------------
+#
+# sonic# show ipv6 dhcp snooping binding
+# !
+# MAC Address        IP Address       VLAN   Interface    Type     Lease (Secs)
+# -----------------  ---------------  ----   -----------  -------  -----------
+# 00:b0:d0:63:c2:26  192.0.2.146      1      Ethernet4    static   NA         
+# 28:21:28:15:c1:1b  141.202.222.118  1      Ethernet2    static   NA         
+# aa:f7:67:fc:f4:9a  156.33.90.167    2      PortChannel1  static   NA         
+# !
+
+- name: Replace DHCPv6 snooping bindings
+  dellemc.enterprise_sonic.sonic_dhcp_snooping:
+    config:
+      afis:
+        - afi: ipv6
+          source_bindings:
+            - mac_addr: 00:b0:d0:63:c2:26
+              ip_addr: 192.0.2.146
+              intf_name: Ethernet4
+              vlan_id: 3
+    state: replaced
+
+# After State:
+# ------------
+#
+# sonic# show ipv6 dhcp snooping binding
+# !
+# MAC Address        IP Address       VLAN   Interface    Type     Lease (Secs)
+# -----------------  ---------------  ----   -----------  -------  -----------
+# 00:b0:d0:63:c2:26  192.0.2.146      3      Ethernet4    static   NA         
+# 28:21:28:15:c1:1b  141.202.222.118  1      Ethernet2    static   NA         
+# aa:f7:67:fc:f4:9a  156.33.90.167    2      PortChannel1  static   NA   
+# !


### PR DESCRIPTION
The DHCP Snooping model definition for SONiC.

The 1st PR incorrectly had changes made on the master branch instead of on a new branch; that's fixed in this PR.