### PR TITLE
IOS - ios_user_global module

### DIFF
--- a/models/ios/user_global/ios_user_global.yml
+++ b/models/ios/user_global/ios_user_global.yml
@@ -1,0 +1,164 @@
+module: ios_user_global
+short_description: Resource module to configure user and enable
+description:
+  - This module provides declarative management of user and enable on Cisco IOS devices
+version_added: 4.7.0
+author:
+  - Ambroise Rosset (@earendilfr)
+notes:
+  - Tested against Cisco IOSXE Version 17.3 on CML.
+  - This module works with connection C(network_cli).
+options:
+  config:
+    description: A dictionary of user and enable options
+    type: dict
+    suboptions:
+      enable:
+        description: A dictionary of options for enable password
+        elements: dict
+        suboptions:
+          password:
+            description:
+              - Define the password or secret for enable role (MAX of 25 characters)
+            type: dict
+            suboptions:
+              type:
+                description:
+                  - Choose the type of password
+                  - I(password) for the old reversible algorythn
+                  - I(secret) to use the more recent and secure algorithm
+                choices:
+                  - password
+                  - secret
+                default: secret
+                type: str
+              hash:
+                description:
+                  - Specifies the type of hash used in password provided
+                  - C(0) - UNENCRYPTED password (I(Default))
+                  - C(5) - MD5 HASHED secret
+                  - C(6) - ENCRYPTED password (require a crypto-key on device)
+                  - C(7) - HIDDEN password
+                  - C(8) - PBKDF2 HASHED secret
+                  - C(9) - SCRYPT HASHED secret
+                choices: [ 0, 5, 6, 7, 8, 9 ]
+                default: 0
+                type: int
+              value:
+                description:
+                  - The actual hashed password to be configured on the device
+                  - The password should be complient with the C(hash) parameter choose
+                    previously
+                type: str
+          level:
+            description:
+              - Set exec level password
+              - The I(level) valu should be between C(1) and C(15)
+            type: int
+        type: list
+      users:
+        description: Define a user with new command
+        elements: dict
+        suboptions:
+          name:
+            description:
+              - The name of the user
+            type: str
+            required: true
+          command:
+            description:
+              - Type of command used to manage this user
+              - Could be I(old) for C(username) or I(new) for C(user-name)
+            choices:
+              - new
+              - old
+            default: old
+            type: str
+          parameters:
+            description:
+              - List of parameters associated of the user
+            type: dict
+            suboptions:
+              nopassword:
+                description:
+                  - No password is required for the user to log in
+                type: bool
+              password:
+                description:
+                  -  Define the password or secret for user (MAX of 25 characters)
+                type: dict
+                suboptions:
+                  type:
+                    description:
+                      - Choose the type of password
+                      - I(password) for the old reversible algorythn
+                      - I(secret) to use the more recent and secure algorithm
+                    choices:
+                      - password
+                      - secret
+                    default: secret
+                    type: str
+                  hash:
+                    description:
+                      - Specifies the type of hash used in password provided
+                      - C(0) - UNENCRYPTED password (I(Default))
+                      - C(5) - MD5 HASHED secret
+                      - C(6) - ENCRYPTED password (require a crypto-key on device)
+                      - C(7) - HIDDEN password
+                      - C(8) - PBKDF2 HASHED secret
+                      - C(9) - SCRYPT HASHED secret
+                    choices: [ 0, 5, 6, 7, 8, 9 ]
+                    default: 0
+                    type: int
+                  value:
+                    description:
+                      - The actual hashed password to be configured on the device
+                      - The password should be complient with the C(hash) parameter choose
+                        previously
+                    type: str
+              privilege:
+                description:
+                  - Set user privilege level
+                  - The I(privilege) value should be between C(1) and C(15)
+                type: int
+              view:
+                description:
+                  - Set view name
+                type: str
+        type: list
+  running_config:
+    description:
+      - This option is used only with state I(parsed).
+      - The value of this option should be the output received from the IOS device
+        by executing the command B(show running-config | section ^username|^enable).
+      - The state I(parsed) reads the configuration from C(running_config) option and
+        transforms it into Ansible structured data as per the resource module's argspec
+        and the value is then returned in the I(parsed) key within the result.
+    type: str
+  state:
+    choices:
+      - merged
+      - overridden
+      - deleted
+      - rendered
+      - gathered
+      - parsed
+    default: merged
+    description:
+      - The state the configuration should be left in
+      - The states I(rendered), I(gathered) and I(parsed) does not perform any change
+        on the device.
+      - The state I(rendered) will transform the configuration in C(config) option to
+        platform specific CLI commands which will be returned in the I(rendered) key
+        within the result. For state I(rendered) active connection to remote host is
+        not required.
+      - The state I(gathered) will fetch the running configuration from device and transform
+        it into structured data in the format as per the resource module argspec and
+        the value is returned in the I(gathered) key within the result.
+      - The state I(parsed) reads the configuration from C(running_config) option and
+        transforms it into JSON format as per the resource module parameters and the
+        value is returned in the I(parsed) key within the result. The value of C(running_config)
+        option should be the same format as the output of command
+        I(show running-config | section ^username|^enable) executed on device. For state I(parsed) 
+        active connection to remote host is not required.
+    type: str


### PR DESCRIPTION
New module to configure user on IOS devices
Could be used to replace the ios_user

Related to the PR https://github.com/ansible-collections/cisco.ios/pull/909