### PR TITLE
Add support for Bgp asn notation

### DIFF
--- a/models/enterprise_sonic/bgp/deleted_example_01.txt
+++ b/models/enterprise_sonic/bgp/deleted_example_01.txt
@@ -14,6 +14,10 @@
 # bestpath med missing-as-worst confed
 # bestpath compare-routerid
 #!
+#router bgp 10.2 vrf VrfCheck3
+# log-neighbor-changes
+# as-notation asdot+
+#!
 #router bgp 4
 # router-id 10.2.2.4
 # bestpath as-path ignore
@@ -54,6 +58,8 @@
 #            med:
 #              confed: True
 #              missing_as_worst: True
+#        - bgp_as: 10.2
+#          as_notation: "asdot+"
 #      state: deleted
 # After state:
 # ------------
@@ -65,6 +71,9 @@
 #router bgp 11 vrf VrfCheck2
 # log-neighbor-changes
 # bestpath compare-routerid
+#!
+#router bgp 655362 vrf VrfCheck3
+# log-neighbor-changes
 #!
 #router bgp 4
 # log-neighbor-changes

--- a/models/enterprise_sonic/bgp/deleted_example_02.txt
+++ b/models/enterprise_sonic/bgp/deleted_example_02.txt
@@ -14,6 +14,9 @@
 # bestpath med missing-as-worst confed
 # bestpath compare-routerid
 #!
+#router bgp 655362 vrf VrfCheck3
+# log-neighbor-changes
+#!
 #router bgp 4
 # router-id 10.2.2.4
 # bestpath as-path ignore

--- a/models/enterprise_sonic/bgp/merged_example_01.txt
+++ b/models/enterprise_sonic/bgp/merged_example_01.txt
@@ -40,6 +40,10 @@
 #            med:
 #              confed: True
 #              missing_as_worst: True
+#        - bgp_as: 655362
+#          log_neighbor_changes: True
+#          vrf_name: 'VrfCheck3'
+#          as_notation: "asdot+"
 #      state: merged
 #
 # After state:
@@ -55,6 +59,10 @@
 # bestpath as-path ignore
 # bestpath med missing-as-worst confed
 # bestpath compare-routerid
+#!
+#router bgp 10.2 vrf VrfCheck3
+# log-neighbor-changes
+# as-notation asdot+
 #!
 #router bgp 4
 # router-id 10.2.2.4

--- a/models/enterprise_sonic/bgp/sonic_bgp.yaml
+++ b/models/enterprise_sonic/bgp/sonic_bgp.yaml
@@ -31,6 +31,7 @@ DOCUMENTATION: |
         bgp_as:
           description:
             - Specifies the BGP Autonomous System (AS) number to configure on the device.
+            - The range is from 1 to 4294967295 or asdot notation.
           type: str
           required: true
         vrf_name:
@@ -50,7 +51,7 @@ DOCUMENTATION: |
           description:
             - Specify the AS number notation format
           type: str
-          choices: [ 'asdot', 'asdot+' ]
+          choices: ['asdot', 'asdot+']
         bestpath:
           description:
             - Configures the BGP bestpath.

--- a/models/enterprise_sonic/bgp/sonic_bgp.yaml
+++ b/models/enterprise_sonic/bgp/sonic_bgp.yaml
@@ -46,6 +46,11 @@ DOCUMENTATION: |
           description:
             - Enable/disable logging neighbor up/down and reset reason.
           type: bool
+        as_annotation:
+          description:
+            - Specify the AS number notation format
+          type: str
+          choices: [ 'asdot', 'asdot+' ]
         bestpath:
           description:
             - Configures the BGP bestpath.

--- a/models/enterprise_sonic/bgp_neighbors/sonic_bgp_neighbors.yaml
+++ b/models/enterprise_sonic/bgp_neighbors/sonic_bgp_neighbors.yaml
@@ -54,8 +54,8 @@ DOCUMENTATION: |
                 peer_as:
                   description:
                     - Specifies remote AS number.
-                    - The range is from 1 to 4294967295.
-                  type: int
+                    - The range is from 1 to 4294967295 or asdot notation.
+                  type: str
                 peer_type:
                   description:
                     - Specifies type of bgp peer.
@@ -177,7 +177,8 @@ DOCUMENTATION: |
                 as:
                   description:
                     - Local autonomous system number.
-                  type: int
+                    - The range is from 1 to 4294967295 or asdot notation.
+                  type: str
                   required: True
                 no_prepend:
                   description:
@@ -324,8 +325,8 @@ DOCUMENTATION: |
                 peer_as:
                   description:
                     - Specifies remote AS number.
-                    - The range is from 1 to 4294967295.
-                  type: int
+                    - The range is from 1 to 4294967295 or asdot notation.
+                  type: str
                 peer_type:
                   description:
                     - Specifies type of bgp peer.
@@ -450,7 +451,8 @@ DOCUMENTATION: |
                 as:
                   description:
                     - Local autonomous system number.
-                  type: int
+                    - The range is from 1 to 4294967295 or asdot notation.
+                  type: str
                   required: True
                 no_prepend:
                   description:


### PR DESCRIPTION
Add BGP global "as_notation" attribute for configuration the asn notation format for the Bgp instance. Also update Bgp asn to type str to accommodate the asdot notation.