### PR TITLE
add new options for auth_type sub-field of the SNMP model

### DIFF
--- a/models/enterprise_sonic/snmp/merged_example_03.txt
+++ b/models/enterprise_sonic/snmp/merged_example_03.txt
@@ -13,7 +13,7 @@
       user:
         - name: user2
           auth:
-            auth_type: sha
+            auth_type: sha2-256
             key: shakey5
           priv:
             priv_type: aes

--- a/models/enterprise_sonic/snmp/merged_example_03.txt
+++ b/models/enterprise_sonic/snmp/merged_example_03.txt
@@ -1,0 +1,31 @@
+# Using merged
+#
+# Before state:
+#---------------
+#
+# show running-configuration | grep snmp
+# (no snmp-server configuration present)
+#
+
+- name: Merge specific option snmp-server configuration
+  sonic_snmp:
+    config:
+      user:
+        - name: user2
+          auth:
+            auth_type: sha
+            key: shakey5
+          priv:
+            priv_type: aes
+            key: aes-128
+          encrypted: false
+    state: merged
+
+# After State:
+#---------------
+#
+# show running-configuration | grep snmp
+#
+# snmp-server user user2 group group-lab
+# auth sha2-256 auth-password U2FsdGVkX18J+L+L9OyQYWpAkGUrTgcg/6xzZoDjCbQw1ISHJ5mxmxrYZgQypEUXDeNe6rBupsc9sVDJBKxrwA==
+# priv aes-128 priv-password U2FsdGVkX1/Xs+ffZvdV9YzfyGHgIJ+zkLRPfF3/WgYIE1S4Ribvbzhu5chpHHI7ooCBpcVxYZotAXDzgetxvQ==

--- a/models/enterprise_sonic/snmp/sonic_snmp.yml
+++ b/models/enterprise_sonic/snmp/sonic_snmp.yml
@@ -93,6 +93,9 @@ DOCUMENTATION: |
                     choices:
                       - md5
                       - sha
+                      - sha2-256
+                      - sha2-512
+                      - sha2-384
                   key: 
                     description: 
                       - Authentication key
@@ -283,5 +286,6 @@ EXAMPLES:
   - deleted_example_02.txt
   - merged_example_01.txt
   - merged_example_02.txt
+  - merged_example_03.txt
   - replaced_example_01.txt
   - overridden_example_01.txt


### PR DESCRIPTION
Add the bellow options to the 'auth_type' subfield the 'user' field in the SNMP model:
       - sha2-256
        - sha2-384
        - sha2-512